### PR TITLE
feat(security): protected file deny patterns + 3 safety hooks

### DIFF
--- a/hooks/claude-infra-guard.sh
+++ b/hooks/claude-infra-guard.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+# claude-infra-guard.sh - PreToolUse Hook (Edit|Write)
+# Prevents agents from modifying Claude Forge system files.
+# This is a self-protection mechanism: agents cannot alter their own rules.
+#
+# Exit codes:
+#   0 = allow
+#   2 = block
+#
+# Outside .claude/: always allow
+# Inside .claude/: block security boundary files, allow the rest
+#
+# Blocked (security boundary):
+#   claude-infra-guard.sh (self-protection)
+#   settings*.json (permission rules)
+#   .claude/hooks/*.sh (security hooks)
+#   .claude/commands/*.md (command definitions)
+#   .claude/skills/**/* (skill definitions)
+#   .claude/agents/*.md (agent definitions)
+#   .claude/rules/**/*.md (behavior rules)
+#   .claude/reference/**/*.md (reference docs)
+
+INPUT=$(cat)
+
+FILE_PATH=$(echo "$INPUT" | python3 -c '
+import sys, json
+try:
+    d = json.load(sys.stdin)
+    print(d.get("tool_input", {}).get("file_path", ""))
+except:
+    print("")
+' 2>/dev/null)
+
+if [[ -z "$FILE_PATH" ]]; then
+    exit 0
+fi
+
+# Not a .claude/ path → allow
+if [[ "$FILE_PATH" != *"/.claude/"* ]] && [[ "$FILE_PATH" != *"\\.claude\\"* ]]; then
+    exit 0
+fi
+
+# ── Security boundary check ──
+
+NORMALIZED="${FILE_PATH//\\//}"
+BASENAME=$(basename "$NORMALIZED")
+
+# Self-protection: block modification of this hook
+if [[ "$BASENAME" == "claude-infra-guard.sh" ]]; then
+    echo "BLOCKED: infra-guard self-modification is not allowed" >&2
+    exit 2
+fi
+
+# Permission boundary: block settings files
+if [[ "$BASENAME" == settings*.json ]]; then
+    echo "BLOCKED: settings file modification ($BASENAME). Use settings.local.json for overrides." >&2
+    exit 2
+fi
+
+# hooks/ directory protection
+if [[ "$NORMALIZED" == *"/.claude/hooks/"* ]]; then
+    echo "BLOCKED: hook file ($BASENAME). Hooks are protected system files." >&2
+    exit 2
+fi
+
+# commands/ directory protection
+if [[ "$NORMALIZED" == *"/.claude/commands/"* ]]; then
+    echo "BLOCKED: command file ($BASENAME). Commands are protected system files." >&2
+    exit 2
+fi
+
+# skills/ directory protection
+if [[ "$NORMALIZED" == *"/.claude/skills/"* ]]; then
+    echo "BLOCKED: skill file ($BASENAME). Skills are protected system files." >&2
+    exit 2
+fi
+
+# agents/ directory protection
+if [[ "$NORMALIZED" == *"/.claude/agents/"* ]]; then
+    echo "BLOCKED: agent file ($BASENAME). Agents are protected system files." >&2
+    exit 2
+fi
+
+# rules/ directory protection
+if [[ "$NORMALIZED" == *"/.claude/rules/"* ]]; then
+    echo "BLOCKED: rule file ($BASENAME). Rules are protected system files." >&2
+    exit 2
+fi
+
+# reference/ directory protection
+if [[ "$NORMALIZED" == *"/.claude/reference/"* ]]; then
+    echo "BLOCKED: reference file ($BASENAME). Reference docs are protected system files." >&2
+    exit 2
+fi
+
+# Everything else → allow
+exit 0

--- a/hooks/npm-scripts-guard.sh
+++ b/hooks/npm-scripts-guard.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+# npm-scripts-guard.sh - PreToolUse Hook (Bash)
+# Warns when running npm/yarn/pnpm after package.json scripts were modified.
+# Prevents accidental execution of tampered scripts.
+#
+# Exit codes: always 0 (warn only, never blocks)
+# Shows warning once per session.
+
+INPUT=$(cat)
+
+COMMAND=$(echo "$INPUT" | python3 -c '
+import sys, json
+try:
+    d = json.load(sys.stdin)
+    print(d.get("tool_input", {}).get("command", ""))
+except:
+    print("")
+' 2>/dev/null)
+
+if [[ -z "$COMMAND" ]]; then
+    exit 0
+fi
+
+# Check if it's an npm/yarn/pnpm run command
+if ! echo "$COMMAND" | grep -qE '\b(npm\s+run|npm\s+start|npm\s+test|yarn\s|pnpm\s+run)\b'; then
+    exit 0
+fi
+
+# Skip if not in a git repo
+if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    exit 0
+fi
+
+# Check if package.json scripts were modified (staged or unstaged)
+SCRIPTS_CHANGED=$(git diff --unified=0 -- package.json 2>/dev/null | grep -c '"scripts"' || true)
+SCRIPTS_STAGED=$(git diff --cached --unified=0 -- package.json 2>/dev/null | grep -c '"scripts"' || true)
+
+if [[ "$SCRIPTS_CHANGED" -eq 0 ]] && [[ "$SCRIPTS_STAGED" -eq 0 ]]; then
+    exit 0
+fi
+
+# Warn once per session (marker file)
+SESSION_ID="${CLAUDE_SESSION_ID:-unknown}"
+MARKER_DIR="/tmp/npm-scripts-guard"
+mkdir -p "$MARKER_DIR" 2>/dev/null
+MARKER="$MARKER_DIR/$SESSION_ID"
+
+if [[ -f "$MARKER" ]]; then
+    exit 0
+fi
+touch "$MARKER"
+
+echo "[warn] package.json scripts were modified in this session. Please verify the command before running." >&2
+exit 0

--- a/hooks/stop-verify.sh
+++ b/hooks/stop-verify.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# stop-verify.sh - Stop Hook
+# Reminds to run verification before ending a session with code changes.
+# Only triggers when actual code changes exist (git diff non-empty).
+#
+# Exit codes: always 0 (reminder only, never blocks)
+
+# Skip if not in a git repo
+if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    exit 0
+fi
+
+# Skip if no code changes in this session
+DIFF_LINES=$(git diff --stat 2>/dev/null | wc -l)
+STAGED_LINES=$(git diff --cached --stat 2>/dev/null | wc -l)
+
+if [[ "$DIFF_LINES" -eq 0 ]] && [[ "$STAGED_LINES" -eq 0 ]]; then
+    exit 0
+fi
+
+# Check if verification was run (marker file from /handoff-verify or test commands)
+SESSION_ID="${CLAUDE_SESSION_ID:-unknown}"
+MARKER="/tmp/stop-verify-$SESSION_ID"
+
+if [[ -f "$MARKER" ]]; then
+    exit 0
+fi
+
+echo "[reminder] Code changes detected but no verification was run this session. Consider running /handoff-verify before ending." >&2
+exit 0

--- a/settings.json
+++ b/settings.json
@@ -95,7 +95,23 @@
       "Bash(/usr/bin/perl -e *)*",
       "Bash(xargs *)*",
       "Bash(open http*)*",
-      "Bash(source /dev/*)*"
+      "Bash(source /dev/*)*",
+      "Read(*/.env)",
+      "Read(*/.env.*)",
+      "Read(*/.ssh/id_*)",
+      "Read(*/.aws/credentials)",
+      "Read(*/.npmrc)",
+      "Read(*/.netrc)",
+      "Read(*/.git-credentials)",
+      "Read(*/.docker/config.json)",
+      "Grep(*/.env)",
+      "Grep(*/.env.*)",
+      "Grep(*/.ssh/id_*)",
+      "Grep(*/.aws/credentials)",
+      "Grep(*/.npmrc)",
+      "Grep(*/.netrc)",
+      "Grep(*/.git-credentials)",
+      "Grep(*/.docker/config.json)"
     ]
   },
   "hooks": {
@@ -106,6 +122,21 @@
           {
             "type": "command",
             "command": "~/.claude/hooks/remote-command-guard.sh",
+            "timeout": 5000
+          },
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/npm-scripts-guard.sh",
+            "timeout": 5000
+          }
+        ]
+      },
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/claude-infra-guard.sh",
             "timeout": 5000
           }
         ]
@@ -214,6 +245,15 @@
           {
             "type": "command",
             "command": "~/.claude/hooks/session-wrap-suggest.sh"
+          }
+        ]
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/stop-verify.sh",
+            "timeout": 5000
           }
         ]
       }


### PR DESCRIPTION
## Context
Contribution from jyh-system. Forge deny list covers Bash commands well but protected files can still be accessed via Read/Grep tools.

## What This Adds

### Deny List: 16 new patterns
Protected file access prevention via Read and Grep tools (covers ssh keys, cloud credentials, package manager configs, git credentials, container configs).

### 3 New Hooks

| Hook | Trigger | Purpose |
|------|---------|---------|
| **claude-infra-guard.sh** | PreToolUse (Edit/Write) | Blocks modification of .claude/ system files (hooks, commands, skills, agents, rules, settings). Prevents agents from altering their own safety rules. |
| **npm-scripts-guard.sh** | PreToolUse (Bash) | Warns when running npm/yarn/pnpm after package.json scripts were modified in the session. Once per session, warn only. |
| **stop-verify.sh** | Stop | Reminds to run /handoff-verify when ending a session with uncommitted code changes. Skips exploration-only sessions (no alert fatigue). |

## Changes
- `settings.json` — 16 deny patterns added + 3 hooks registered
- `hooks/claude-infra-guard.sh` (75 lines) — new
- `hooks/npm-scripts-guard.sh` (43 lines) — new
- `hooks/stop-verify.sh` (30 lines) — new

## Existing Code Impact
- settings.json deny: append-only, no existing patterns modified
- settings.json hooks: new matchers added alongside existing ones
- No existing hooks, commands, or agents modified

## Test Plan
- [ ] Read a protected credential file -> should be denied
- [ ] Normal file Read/Grep -> should work
- [ ] Edit a file in .claude/hooks/ -> claude-infra-guard blocks
- [ ] Modify package.json scripts then run npm test -> warning shown
- [ ] End session with code changes -> stop-verify reminds
- [ ] End session without changes -> stop-verify stays silent

Generated with Claude Code
