### PR TITLE
fix(agents): add Task to verify-agent tools array

### DIFF
--- a/agents/verify-agent.md
+++ b/agents/verify-agent.md
@@ -2,7 +2,7 @@
 ---
 name: verify-agent
 description: Fresh-context verification sub-agent. Runs build/type/lint/test verification pipeline.
-tools: ["Read", "Write", "Edit", "Bash", "Grep", "Glob"]
+tools: ["Read", "Write", "Edit", "Bash", "Grep", "Glob", "Task"]
 model: sonnet
 memory: project
 color: cyan


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Bug

`agents/verify-agent.md` declares `Task` as a required tool in two places — the `<Tool_Usage>` section and the Configuration table — but the frontmatter `tools` array omits it:

```yaml
# Before (broken)
tools: ["Read", "Write", "Edit", "Bash", "Grep", "Glob"]

# After (fixed)
tools: ["Read", "Write", "Edit", "Bash", "Grep", "Glob", "Task"]
```

## Why it matters

At `effort:max`, `verify-agent` is supposed to spawn `security-reviewer` as a subagent via `Task`. Without `Task` declared in the `tools` array, the runtime cannot grant that permission and the spawn silently fails. Any handoff-verify invocation with `--security` or `effort:max` will reach Step 6 and produce no security review result.

The cross-component analysis in the audit confirms: `commands/handoff-verify.md` includes `Task` in its own `allowed-tools` and explicitly dispatches to `agents/verify-agent.md`, but the agent itself cannot complete the delegation.

## Fix

One-line addition of `"Task"` to the frontmatter tools array, matching what the agent body and Configuration table already document as required.