### PR TITLE
fix(commands): add missing YAML frontmatter to three commands

### DIFF
--- a/commands/test-coverage.md
+++ b/commands/test-coverage.md
@@ -1,3 +1,8 @@
+---
+description: Analyze test coverage and generate missing tests to reach 80%+ coverage
+allowed-tools: Bash, Read, Write, Glob, Grep
+---
+
 # Test Coverage
 
 Analyze test coverage and generate missing tests:

--- a/commands/update-codemaps.md
+++ b/commands/update-codemaps.md
@@ -1,3 +1,8 @@
+---
+description: Analyze codebase structure and update architecture documentation in codemaps/
+allowed-tools: Read, Write, Glob, Bash
+---
+
 # Update Codemaps
 
 Analyze the codebase structure and update architecture documentation:

--- a/commands/update-docs.md
+++ b/commands/update-docs.md
@@ -1,3 +1,8 @@
+---
+description: Sync documentation from source-of-truth (package.json, .env.example)
+allowed-tools: Read, Write, Glob, Bash
+---
+
 # Update Documentation
 
 Sync documentation from source-of-truth:


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Bug

Three commands have no YAML frontmatter block at all — their files open directly with a `#` heading:

| File | Missing |
|------|---------|
| `commands/update-docs.md` | `description`, `allowed-tools` |
| `commands/test-coverage.md` | `description`, `allowed-tools` |
| `commands/update-codemaps.md` | `description`, `allowed-tools` |

## Why it matters

Claude Code reads the YAML frontmatter to register slash commands. Without it, these three commands are invisible to the runtime — they cannot be invoked as `/update-docs`, `/test-coverage`, or `/update-codemaps`. The command bodies are fully written and ready; only the registration block is missing.

## Fix

Added minimal YAML frontmatter matching the format documented in `CONTRIBUTING.md` (description + allowed-tools derived from each command's body):

- `update-docs.md` — reads package.json and .env.example, writes docs: `Read, Write, Glob, Bash`
- `test-coverage.md` — runs test suite with coverage flags, writes tests: `Bash, Read, Write, Glob, Grep`
- `update-codemaps.md` — scans source files, writes codemaps: `Read, Write, Glob, Bash`

No body content was changed.