### PR TITLE
fix(agents): add tools array to observer agent frontmatter

### DIFF
--- a/skills/continuous-learning-v2/agents/observer.md
+++ b/skills/continuous-learning-v2/agents/observer.md
@@ -1,6 +1,7 @@
 ---
 name: observer
 description: Background agent that analyzes session observations to detect patterns and create instincts. Uses Haiku for cost-efficiency.
+tools: ["Read", "Write", "Glob", "Grep"]
 model: haiku
 run_mode: background
 ---


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Bug

`skills/continuous-learning-v2/agents/observer.md` has `model` and `run_mode` declared in its frontmatter but no `tools` array:

```yaml
# Before (broken)
---
name: observer
description: ...
model: haiku
run_mode: background
---

# After (fixed)
---
name: observer
description: ...
tools: ["Read", "Write", "Glob", "Grep"]
model: haiku
run_mode: background
---
```

## Why it matters

Without a `tools` declaration, the runtime cannot grant tool access to the agent. The observer's two core operations — reading `~/.claude/homunculus/observations.jsonl` and writing instinct files to `~/.claude/homunculus/instincts/personal/` — both require tool access (Read and Write respectively). The entire continuous-learning pipeline depends on this agent; a missing tools declaration makes it non-functional.

The parent skill `skills/continuous-learning-v2/SKILL.md` describes the complete hook-based observation pipeline clearly, making the missing tools declaration in the child agent a straightforward omission.

## Fix

Added `tools: ["Read", "Write", "Glob", "Grep"]` to the frontmatter, matching exactly what the agent body documents it needs to read observations and write instincts.