### PR TITLE
fix(scripts): pin md-to-docx Python dependencies to exact versions

### DIFF
--- a/scripts/md-to-docx/requirements.txt
+++ b/scripts/md-to-docx/requirements.txt
@@ -1,2 +1,2 @@
-python-docx>=0.8.11
-lxml>=4.9.0
+python-docx==1.1.2
+lxml==5.2.2


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Security Finding (Low)

`scripts/md-to-docx/requirements.txt` uses minimum-version constraints (`>=`) rather than exact pins:

```
# Before
python-docx>=0.8.11
lxml>=4.9.0

# After
python-docx==1.1.2
lxml==5.2.2
```

## Why it matters

Each time a user runs `install.sh`, pip resolves to the latest available version. If either package is compromised upstream (typosquat, malicious maintainer commit, hijacked account), the next install silently pulls in the malicious version. Exact pins lock the install to a known-good state and ensure every user gets the same tested environment.

## Fix

Pinned both packages to current stable tested versions:
- `python-docx` → 1.1.2 (latest stable as of audit date)
- `lxml` → 5.2.2 (latest stable as of audit date)

To update pins in future: run `pip install python-docx lxml && pip freeze | grep -E 'python-docx|lxml'` in a clean virtualenv.