### PR TITLE
docs(readme): v3.0.1 동기화 — 4 MCP / plugin install / CI marketplace-schema

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -27,13 +27,13 @@
   <a href="README.md">English</a>
 </p>
 
-> 🎉 **v3.0 공개 (2026년 4월)** — Anthropic 2026 표준에 정렬: Hooks 21 이벤트 · Subagent frontmatter v2 · Skills/Commands 하이브리드 정책 · MCP 최소 구성(3개). 상세: [MIGRATION.md](MIGRATION.md) / [MIGRATION.ko.md](MIGRATION.ko.md).
+> 🎉 **v3.0.1 공개 (2026년 4월)** — Claude Code 공식 플러그인으로 설치 가능: `/plugin install sangrokjung/claude-forge`. Anthropic 2026 표준 정렬(Hooks 21+ 이벤트 · Subagent frontmatter v2 · Skills/Commands 하이브리드 정책) + MCP 최소 구성(4개: playwright · context7 · jina-reader · chrome-devtools@0.23.0). 상세: [MIGRATION.md](MIGRATION.md) / [MIGRATION.ko.md](MIGRATION.ko.md), [Release v3.0.1](https://github.com/sangrokjung/claude-forge/releases/tag/v3.0.1).
 
 ---
 
 ## Claude Forge란?
 
-Claude Forge는 **Claude Code**를 기본 CLI에서 **완전한 개발 환경**으로 변환합니다. 설치 한 번으로 **11개 전문 에이전트**(Opus 6 + Sonnet 5, frontmatter v2), **33개 슬래시 커맨드**, **24개 스킬 워크플로우**(16 native + 8 commands에서 이전), **15개 자동화 훅 + 9개 opt-in 예제**(21 lifecycle 이벤트 커버), **9개 규칙 파일**, **3개 MCP 서버**(minimal, 8개 이상 optional)가 모두 연결되어 즉시 사용 가능합니다.
+Claude Forge는 **Claude Code**를 기본 CLI에서 **완전한 개발 환경**으로 변환합니다. 설치 한 번으로 **11개 전문 에이전트**(Opus 6 + Sonnet 5, frontmatter v2), **33개 슬래시 커맨드**, **24개 스킬 워크플로우**(16 native + 8 commands에서 이전), **15개 자동화 훅 + 9개 opt-in 예제**(21 lifecycle 이벤트 커버), **9개 규칙 파일**, **4개 MCP 서버**(minimal · chrome-devtools 포함, 7개 이상 optional)가 모두 연결되어 즉시 사용 가능합니다.
 
 > oh-my-zsh가 터미널을 강화하듯, Claude Forge는 AI 코딩 어시스턴트를 **파워 유저 도구**로 업그레이드합니다.
 
@@ -62,10 +62,22 @@ claude
 | **Hooks 21 이벤트** | 라이프사이클 훅이 5개에서 21개로 확장되었습니다. Opt-in 샘플은 [`hooks/examples/`](hooks/examples/)에, 전체 카탈로그는 [`hooks/README.md`](hooks/README.md)에 있습니다. |
 | **Subagent Frontmatter v2** | 10개 선택 필드 추가: `isolation`, `background`, `memory`, `maxTurns`, `skills`, `mcpServers`, `effort`, `hooks`, `permissionMode`, `disallowedTools`. 스키마: [`reference/agent-schema.json`](reference/agent-schema.json). 상세: [`docs/AGENT-FRONTMATTER-V2.md`](docs/AGENT-FRONTMATTER-V2.md). |
 | **Skills/Commands 하이브리드 정책** | 경계를 [`docs/SKILLS-VS-COMMANDS.md`](docs/SKILLS-VS-COMMANDS.md)에 명문화. 디렉토리 형태의 커맨드 8개가 `skills/`로 이전되며, 기존 경로는 심볼릭 링크로 호환성 유지. |
-| **MCP 최소 구성 (3개)** | 기본 서버를 `playwright` · `context7` · `jina-reader`로 축소. 레거시 전체 세트는 [`mcp-servers.optional.json`](mcp-servers.optional.json)에 보존. 전환 레시피: [`docs/MCP-MIGRATION.md`](docs/MCP-MIGRATION.md). |
+| **MCP 최소 구성 (v3.0.1, 4개)** | 기본 서버: `playwright` · `context7` · `jina-reader` · `chrome-devtools-mcp@0.23.0` (Google ChromeDevTools 공식, Apache-2.0 — Lighthouse/Core Web Vitals 감사를 위해 v3.0.1에서 승격). 레거시 전체 세트는 [`mcp-servers.optional.json`](mcp-servers.optional.json)에 보존. 전환 레시피: [`docs/MCP-MIGRATION.md`](docs/MCP-MIGRATION.md). 결정 근거: [`docs/adr/ADR-001-mcp-default-set.md`](docs/adr/ADR-001-mcp-default-set.md). |
 | **CLAUDE.md 템플릿 + @import** | [`setup/CLAUDE.md.template`](setup/CLAUDE.md.template)과 [`docs/CLAUDE-MD-GUIDE.md`](docs/CLAUDE-MD-GUIDE.md) 신규. 200줄 원칙과 `@import` 패턴으로 모듈형 프로젝트 지침을 구성합니다. |
 | **settings.json 2026 필드** | 신규 필드: `tui` (깜박임 없는 렌더링), `disableSkillShellExecution` (샌드박싱), `enabledMcpjsonServers` (명시적 허용 목록). |
 | **원커맨드 업그레이드** | `./install.sh --upgrade` — 기존 v2.1 설치를 백업 및 diff 미리보기와 함께 안전하게 마이그레이션합니다. |
+
+### 🔧 v3.0.1 업데이트 (패치)
+
+| 변경 | 설명 |
+|:-----|:-----|
+| **공식 플러그인 설치** | `/plugin install sangrokjung/claude-forge`가 바로 동작합니다. [`.claude-plugin/plugin.json`](.claude-plugin/plugin.json) + [`.claude-plugin/marketplace.json`](.claude-plugin/marketplace.json) 모두 `3.0.1`로 통일. CI `marketplace-schema` 잡이 버전 drift를 자동 차단합니다. |
+| **Chrome DevTools 승격** | 기본 4-서버 MCP 세트에 Lighthouse / Core Web Vitals / 메모리 스냅샷이 합류. `chrome-devtools-mcp@0.23.0`로 버전 고정(supply-chain 강화). |
+| **`hooks/_lib/timing.sh`** | SessionEnd 훅의 실행 시점을 `~/.claude/logs/hook-timing.jsonl`(권한 600)에 기록하는 래퍼 신규. `async: true` 훅의 실제 병렬성을 사후 검증할 수 있음. 오버헤드 약 35 ms. |
+| **CI 트리거 확장** | [`.github/workflows/validate.yml`](.github/workflows/validate.yml)가 전 PR과 `main`/`feat/**`/`fix/**`/`chore/**`/`docs/**`/`ci/**` 푸시에서 실행됩니다(이전에는 `main`만). 총 6개 job. |
+| **Tier 0 스펙 정합성 정정** | 훅 타입을 공식 규격에 맞춤(`command`/`http`/`prompt`/`agent` — 이전 `llm-prompt`/`mcp-tool`). `timeout` 단위 **초**로 정정(이전 ms). Auto Memory 경로 `~/.claude/projects/<project>/memory/`(이전 `<hash>`). |
+| **신규 거버넌스 문서** | [`docs/adr/ADR-001-mcp-default-set.md`](docs/adr/ADR-001-mcp-default-set.md)(MCP 기본 세트 결정 기록, MADR) · [`docs/SETTINGS-COMPATIBILITY.md`](docs/SETTINGS-COMPATIBILITY.md)(UNVERIFIED 필드 추적) · [`docs/MARKETPLACE-SUBMISSION.md`](docs/MARKETPLACE-SUBMISSION.md)(공식 디렉토리 제출 패킷). |
+| **4-방향 독립 회의적 리뷰** | super-research(Tier 0 docs) · security-reviewer · architect · codex-reviewer가 병렬로 패치를 검증. 병합 전 11개 블로킹 이슈 해소. |
 
 ### 🚨 Breaking Changes
 
@@ -205,7 +217,7 @@ graph LR
 | **스킬** | 15+ | `build-system` `security-pipeline` `eval-harness` `team-orchestrator` `session-wrap` ... (+커맨드에서 이전 8개) |
 | **훅** | 18 + 9 예제 | 보안 방어 6개 + 유틸리티 12개(built-in) + 21 lifecycle 이벤트 샘플 9개(opt-in) |
 | **규칙** | 9 | `coding-style` `security` `git-workflow` `golden-principles` `agents-v2` `verification` ... |
-| **MCP 서버** | 3 (minimal) | `playwright` `context7` `jina-reader` — 8개 이상은 [`mcp-servers.optional.json`](mcp-servers.optional.json) |
+| **MCP 서버** | 4 (minimal) | `playwright` `context7` `jina-reader` `chrome-devtools@0.23.0` — 7개 이상은 [`mcp-servers.optional.json`](mcp-servers.optional.json) |
 
 ---
 
@@ -265,13 +277,14 @@ cd claude-forge && ./install.sh
 
 ### MCP 서버 설정
 
-v3.0은 **기본 3개**만 탑재합니다. 나머지는 [`mcp-servers.optional.json`](mcp-servers.optional.json)에서 opt-in으로 복원합니다. 레시피: [`docs/MCP-MIGRATION.md`](docs/MCP-MIGRATION.md).
+v3.0.1은 **기본 4개**를 탑재합니다. 나머지는 [`mcp-servers.optional.json`](mcp-servers.optional.json)에서 opt-in으로 복원합니다. 레시피: [`docs/MCP-MIGRATION.md`](docs/MCP-MIGRATION.md). 근거: [`docs/adr/ADR-001-mcp-default-set.md`](docs/adr/ADR-001-mcp-default-set.md).
 
 | 서버 | 기본 여부 | API 키 필요 | 설명 |
 |:-----|:--------:|:----------:|:-----|
 | **playwright** | ✅ | - | 브라우저 자동화 / E2E |
 | **context7** | ✅ | - | 실시간 라이브러리 문서 조회 |
 | **jina-reader** | ✅ | - | URL → 마크다운 변환 |
+| **chrome-devtools** | ✅ | - | Lighthouse / Core Web Vitals / 메모리 스냅샷 (Google ChromeDevTools 공식, `@0.23.0` 핀) |
 | **memory** | opt-in | - | 영속적 지식 그래프 (Auto Memory로 대체 가능) |
 | **fetch** | opt-in | - | 웹 콘텐츠 가져오기 (`uvx` 필요) |
 | **github** | opt-in | `GITHUB_PERSONAL_ACCESS_TOKEN` | 리포/PR/이슈 관리 (`gh` CLI로 대체 가능) |
@@ -365,9 +378,10 @@ claude-forge/
   ├── skills/                    다단계 스킬 워크플로우 (15+, 하이브리드 정책)
   ├── install.sh                 macOS/Linux 설치 (--upgrade 지원)
   ├── install.ps1                Windows 설치 (--upgrade 지원)
-  ├── mcp-servers.json           MCP 기본 설정 (3 minimal)
-  ├── mcp-servers.optional.json  MCP 선택 서버 (memory/exa/github/fetch...)
-  ├── plugin.json                플러그인 매니페스트 (3.0.0)
+  ├── mcp-servers.json           MCP 기본 설정 (4 minimal)
+  ├── mcp-servers.optional.json  MCP 선택 서버 (memory/exa/github/fetch/time/...)
+  ├── .claude-plugin/plugin.json 플러그인 매니페스트 (3.0.1)
+  ├── .claude-plugin/marketplace.json  마켓플레이스 엔트리 (3.0.1)
   ├── settings.json              Claude Code 설정 (2026 필드)
   ├── MIGRATION.md               v2.1 → v3.0 마이그레이션 가이드 (EN)
   ├── MIGRATION.ko.md            v2.1 → v3.0 마이그레이션 가이드 (KO)
@@ -532,13 +546,14 @@ claude-forge/
 
 ## 🔌 MCP 서버
 
-`mcp-servers.json`에는 **기본 3개**, `mcp-servers.optional.json`에는 **선택 서버**가 사전 구성되어 있습니다 -- `./install.sh` 또는 `claude mcp add`로 설치합니다. 전환 레시피: [`docs/MCP-MIGRATION.md`](docs/MCP-MIGRATION.md).
+`mcp-servers.json`에는 **기본 4개**, `mcp-servers.optional.json`에는 **선택 서버**가 사전 구성되어 있습니다 -- `./install.sh` 또는 `claude mcp add`로 설치합니다. 전환 레시피: [`docs/MCP-MIGRATION.md`](docs/MCP-MIGRATION.md).
 
 | 서버 | 기본 여부 | 용도 |
 |:-----|:--------:|:-----|
 | **playwright** | ✅ | 브라우저 자동화 / E2E |
 | **context7** | ✅ | 실시간 라이브러리 문서 조회 |
 | **jina-reader** | ✅ | URL → 마크다운 변환 |
+| **chrome-devtools** | ✅ | Lighthouse / Core Web Vitals / 메모리 스냅샷 (`@0.23.0`) |
 | **memory** | opt-in | 영속적 지식 그래프 |
 | **exa** | opt-in | AI 기반 웹 검색 |
 | **github** | opt-in | 리포/PR/이슈 관리 |

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-> 🎉 **v3.0 released (April 2026)** — Anthropic 2026 standard alignment: Hooks 21 events · Subagent frontmatter v2 · Skills/Commands hybrid policy · MCP minimal (3 servers). See [MIGRATION.md](MIGRATION.md) / [MIGRATION.ko.md](MIGRATION.ko.md).
+> 🎉 **v3.0.1 released (April 2026)** — installable as an official Claude Code plugin: `/plugin install sangrokjung/claude-forge`. Anthropic 2026 standard alignment (Hooks 21+ events · Subagent frontmatter v2 · Skills/Commands hybrid policy) plus a 4-server MCP minimum (playwright · context7 · jina-reader · chrome-devtools@0.23.0). See [MIGRATION.md](MIGRATION.md) / [MIGRATION.ko.md](MIGRATION.ko.md) and [Release v3.0.1](https://github.com/sangrokjung/claude-forge/releases/tag/v3.0.1).
 
 ---
 
@@ -86,10 +86,22 @@ they want a global install.
 | **Hooks 21 Events** | Lifecycle hooks expanded from 5 to 21 events. Opt-in samples live at [`hooks/examples/`](hooks/examples/) with the full catalog in [`hooks/README.md`](hooks/README.md). |
 | **Subagent Frontmatter v2** | 10 optional fields: `isolation`, `background`, `memory`, `maxTurns`, `skills`, `mcpServers`, `effort`, `hooks`, `permissionMode`, `disallowedTools`. Schema: [`reference/agent-schema.json`](reference/agent-schema.json). Details: [`docs/AGENT-FRONTMATTER-V2.md`](docs/AGENT-FRONTMATTER-V2.md). |
 | **Skills/Commands Hybrid Policy** | Clear boundary documented at [`docs/SKILLS-VS-COMMANDS.md`](docs/SKILLS-VS-COMMANDS.md). 8 directory-form commands are being migrated to `skills/` with symlink compatibility preserved. |
-| **MCP Minimal (3 servers)** | Default set trimmed to `playwright` · `context7` · `jina-reader`. The legacy full set lives in [`mcp-servers.optional.json`](mcp-servers.optional.json). Recipes: [`docs/MCP-MIGRATION.md`](docs/MCP-MIGRATION.md). |
+| **MCP Minimal (4 servers, v3.0.1)** | Default set: `playwright` · `context7` · `jina-reader` · `chrome-devtools-mcp@0.23.0` (Google ChromeDevTools org, Apache-2.0 — promoted in v3.0.1 for Lighthouse / Core Web Vitals audits). The legacy full set lives in [`mcp-servers.optional.json`](mcp-servers.optional.json). Recipes: [`docs/MCP-MIGRATION.md`](docs/MCP-MIGRATION.md). Decision rationale: [`docs/adr/ADR-001-mcp-default-set.md`](docs/adr/ADR-001-mcp-default-set.md). |
 | **CLAUDE.md Template + @import** | New [`setup/CLAUDE.md.template`](setup/CLAUDE.md.template) and [`docs/CLAUDE-MD-GUIDE.md`](docs/CLAUDE-MD-GUIDE.md) with a 200-line principle and `@import` pattern for modular project instructions. |
 | **settings.json 2026 Fields** | New fields: `tui` (flicker-free rendering), `disableSkillShellExecution` (sandbox), `enabledMcpjsonServers` (explicit allowlist). |
 | **Upgrade in One Command** | `./install.sh --upgrade` safely migrates existing v2.1 installs with backup and diff preview. |
+
+### 🔧 What's New in v3.0.1 (patch)
+
+| Change | Description |
+|:-------|:------------|
+| **Official Plugin Install** | `/plugin install sangrokjung/claude-forge` now works out of the box. [`.claude-plugin/plugin.json`](.claude-plugin/plugin.json) + [`.claude-plugin/marketplace.json`](.claude-plugin/marketplace.json) both pinned to `3.0.1`; CI enforces version drift via the new `marketplace-schema` job. |
+| **Chrome DevTools promoted** | Lighthouse / Core Web Vitals / memory snapshots now arrive with the default 4-server MCP set. Pinned at `chrome-devtools-mcp@0.23.0` (supply-chain hardening). |
+| **`hooks/_lib/timing.sh`** | New wrapper records SessionEnd hook timing into `~/.claude/logs/hook-timing.jsonl` (mode 600) so the real parallelism of `async: true` hooks can be audited post-hoc. ~35 ms overhead. |
+| **CI trigger expanded** | [`.github/workflows/validate.yml`](.github/workflows/validate.yml) now runs on every PR and on `main`/`feat/**`/`fix/**`/`chore/**`/`docs/**`/`ci/**` pushes (previously `main` only). 6 jobs total. |
+| **Tier 0 spec corrections** | Hook types aligned to `command`/`http`/`prompt`/`agent` (were `llm-prompt`/`mcp-tool`). `timeout` unit corrected to **seconds** (was ms). Auto Memory path `~/.claude/projects/<project>/memory/` (was `<hash>`). |
+| **New governance docs** | [`docs/adr/ADR-001-mcp-default-set.md`](docs/adr/ADR-001-mcp-default-set.md) (MCP default decision, MADR) · [`docs/SETTINGS-COMPATIBILITY.md`](docs/SETTINGS-COMPATIBILITY.md) (UNVERIFIED field tracking) · [`docs/MARKETPLACE-SUBMISSION.md`](docs/MARKETPLACE-SUBMISSION.md) (official directory submission packet). |
+| **4-way independent review** | super-research (Tier 0 docs) · security-reviewer · architect · codex-reviewer ran in parallel on the patch. 11 blocking issues closed before merge. |
 
 ### 🚨 Breaking Changes
 
@@ -236,7 +248,7 @@ Most developers either use Claude Code with no customization or spend hours asse
 | **Skills** | 15+ | `build-system` `security-pipeline` `eval-harness` `team-orchestrator` `session-wrap` ... (+8 migrated from commands/) |
 | **Hooks** | 15 + 9 examples | 15 built-in (secret filtering, remote command guard, DB protection, security auto-trigger, rate limiting ...) + 9 opt-in samples covering 21 lifecycle events |
 | **Rules** | 9 | `coding-style` `security` `git-workflow` `golden-principles` `agents` `interaction` `verification` ... |
-| **MCP Servers** | 3 (minimal) | `playwright` `context7` `jina-reader` — 8+ more available in [`mcp-servers.optional.json`](mcp-servers.optional.json) |
+| **MCP Servers** | 4 (minimal) | `playwright` `context7` `jina-reader` `chrome-devtools@0.23.0` — 7+ more available in [`mcp-servers.optional.json`](mcp-servers.optional.json) |
 
 ---
 
@@ -298,13 +310,14 @@ Windows uses **file copies** instead of symlinks. Re-run `install.ps1` after `gi
 
 ### MCP Server Setup
 
-v3.0 ships with **3 minimal defaults**. Others are available opt-in via [`mcp-servers.optional.json`](mcp-servers.optional.json). Full recipes: [`docs/MCP-MIGRATION.md`](docs/MCP-MIGRATION.md).
+v3.0.1 ships with **4 minimal defaults**. Others are available opt-in via [`mcp-servers.optional.json`](mcp-servers.optional.json). Full recipes: [`docs/MCP-MIGRATION.md`](docs/MCP-MIGRATION.md). Rationale: [`docs/adr/ADR-001-mcp-default-set.md`](docs/adr/ADR-001-mcp-default-set.md).
 
 | Server | Default? | API Key | Setup |
 |:-------|:--------:|:--------|:------|
 | **playwright** | ✅ | Not required | Auto-installed via `install.sh` |
 | **context7** | ✅ | Not required | Auto-installed via `install.sh` |
 | **jina-reader** | ✅ | Not required | Auto-installed via `install.sh` |
+| **chrome-devtools** | ✅ | Not required | Auto-installed via `install.sh` (pinned `@0.23.0`, Google ChromeDevTools org, Apache-2.0) |
 | **memory** | opt-in | Not required | Merge from `mcp-servers.optional.json` |
 | **fetch** | opt-in | Not required | Requires `uvx` (Python) |
 | **exa** | opt-in | OAuth | `claude mcp add exa --url https://mcp.exa.ai/mcp` |
@@ -391,9 +404,10 @@ claude-forge/
   ├── skills/                    Multi-step skill workflows (15+, hybrid policy)
   ├── install.sh                 macOS/Linux installer (--upgrade supported)
   ├── install.ps1                Windows installer (--upgrade supported)
-  ├── mcp-servers.json           MCP server defaults (3 minimal)
-  ├── mcp-servers.optional.json  Optional MCP servers (memory/exa/github/fetch...)
-  ├── plugin.json                Plugin manifest (3.0.0)
+  ├── mcp-servers.json           MCP server defaults (4 minimal)
+  ├── mcp-servers.optional.json  Optional MCP servers (memory/exa/github/fetch/time/...)
+  ├── .claude-plugin/plugin.json Plugin manifest (3.0.1)
+  ├── .claude-plugin/marketplace.json  Marketplace entry (3.0.1)
   ├── settings.json              Claude Code settings (2026 fields)
   ├── MIGRATION.md               v2.1 → v3.0 migration guide (EN)
   ├── MIGRATION.ko.md            v2.1 → v3.0 migration guide (KO)


### PR DESCRIPTION
## Summary

`/plugin install sangrokjung/claude-forge`가 이미 v3.0.1을 배포하고 있지만, README.md / README.ko.md 본문은 여전히 **v3.0 시점 문자열**("3 servers / 3.0.0")이었습니다. first-touch 정보 정합성을 회복하는 **docs-only** 패치.

## Changes

### README.md
- 상단 notice: `v3.0 released` → `v3.0.1 released`, `/plugin install` 강조, Release v3.0.1 링크
- MCP 관련 4개 구간(What's New 표, What's Inside 표, MCP Server Setup 표, 저장소 구조 다이어그램)에서 `3 servers` → `4 servers` + `chrome-devtools-mcp@0.23.0` 명시
- 신규 섹션 **"What's New in v3.0.1 (patch)"**: 공식 플러그인 설치, Chrome DevTools 승격, `hooks/_lib/timing.sh`, CI 확장, Tier 0 스펙 정정, 신규 거버넌스 문서 3종, 4-way 독립 리뷰 요약

### README.ko.md
- EN 버전과 1:1 대응 한국어 번역
- v3.0 업데이트 표 + Breaking Changes 아래에 **"v3.0.1 업데이트 (패치)"** 섹션 신설

## Verification

| 항목 | 결과 |
|------|------|
| `MCP Minimal (3 servers)` 잔존 | 0건 |
| `plugin.json (3.0.0)` 잔존 | 0건 |
| `MCP 최소 구성(3개)` / `3 (minimal)` 잔존 | 0건 |
| `chrome-devtools` 언급 | EN 5회 · KO 7회 |
| `/plugin install sangrokjung/claude-forge` | EN 4회 · KO 2회 |
| `3.0.1` 버전 표기 | EN 10회 · KO 7회 |

## Test Plan

- [x] `grep`으로 stale 문자열 0건 확인
- [ ] CI `validate.yml` 6 jobs 통과 (docs-only라 marketplace-schema / JSON / Installer Dry-Run 등 모두 무관하게 pass 예상)
- [ ] PR preview에서 렌더링 확인

## Scope

**docs-only**. 코드/설정/기능 변경 없음. v3.0.1 Release와 플러그인 동작은 이 PR과 무관하게 이미 정상.

## Related

- PR #38 (MCP 정리 + 마켓플레이스 등록, merged) — Stage A~C
- PR #31 (feat/v3.0 → main, merged)
- Release v3.0.1 https://github.com/sangrokjung/claude-forge/releases/tag/v3.0.1

🤖 Generated via Claude Code