### PR TITLE
docs(submission): Step 3 실제 필드 구조 반영 (지원 플랫폼 / 라이선스 / Privacy / 이메일)

### DIFF
--- a/docs/MARKETPLACE-SUBMISSION.md
+++ b/docs/MARKETPLACE-SUBMISSION.md
@@ -225,49 +225,32 @@ closed before tagging the release.
 
 ### Step 3 — Submission details
 
-(Fields depend on the UI — typical fields include maintainer, license
-confirmation, "why does this belong here", and free-text context.
-Suggested values below.)
+The actual form has three short input blocks. Field-by-field values:
 
-**Maintainer**: `Sangrok Jung (@sangrokjung)`
+**지원 플랫폼 (Supported platforms)**
+- ☑ **Claude Code** — 체크 (유지)
+- ☐ **Claude Cowork** — **체크하지 말 것** (테스트 미수행; 안내문이 "제출하기
+  전에 이 플랫폼에서 플러그인이 작동하는지 테스트하세요"로 명시)
 
-**License confirmation**: `MIT` (LICENSE file at repo root)
-
-**왜 이 플러그인을 커뮤니티 디렉토리에 제출하나요? (Why submit?)**
+**라이선스 유형 (License type)**
 ```
-Provides a vetted, actively maintained baseline for developers who want to
-operate Claude Code at production quality without hand-assembling agents,
-commands, skills, and hooks. It fills the same role oh-my-zsh fills for zsh.
-A CI workflow (.github/workflows/validate.yml) enforces JSON syntax, plugin
-manifest schema, version drift, SemVer format, agent/skill frontmatter,
-installer dry-run, and secret scanning, so the directory entry is kept in
-sync automatically as new releases ship. CONTRIBUTING.md documents a
-"Publishing to the Plugin Directory" section with a pre-release QA
-checklist.
+MIT
 ```
 
-**추가 컨텍스트 (Additional context)**
-```
-Full submission packet with verification evidence for every reviewer item:
-https://github.com/sangrokjung/claude-forge/blob/main/docs/MARKETPLACE-SUBMISSION.md
+**개인정보 처리방침 URL (Privacy policy URL)**
+→ **공란으로 둘 것** (선택 항목, `*` 표시 없음)
 
-Install-path comparison (explains exactly what /plugin install covers vs
-./install.sh):
-https://github.com/sangrokjung/claude-forge/blob/main/docs/PLUGIN-VS-INSTALL-SH.md
+Why: claude-forge is a client-side tool distribution (slash commands,
+skills, hooks, agents). It does not collect or process personal data on
+any server, so no privacy policy URL exists. Putting a made-up URL or
+substituting `SECURITY.md` (which is a vulnerability-disclosure page, not
+a privacy policy) would be inaccurate. The field is optional.
 
-MCP server migration & license attribution:
-https://github.com/sangrokjung/claude-forge/blob/main/docs/MCP-MIGRATION.md
+**이메일 주소 (Email address)** *
+Pre-filled from the user's Anthropic account. Keep as-is.
 
-Current release: v3.0.1 (tagged + GitHub Release, 2026-04-23).
-All 11 npm MCP packages SemVer-pinned: playwright@0.0.70, context7@2.1.8,
-jina-mcp-tools@1.2.3, chrome-devtools@0.23.0, server-memory@2026.1.26,
-server-github@2025.4.8, sequential-thinking@2025.12.18,
-mcp-server-supabase@0.7.0.
-
-plugin.json follows the official Claude Code plugin manifest spec exactly
-(no custom fields — verified against reference plugins superpowers v5.0.7
-and claude-hud v0.0.11).
-```
+### Final step
+Click **"검토 요청 제출" (Submit for review)** at the bottom of Step 3.
 
 ### Legacy combined template (kept for reference / non-Korean forms)
 


### PR DESCRIPTION
## Summary

사용자가 clau.de 양식 Step 3 스크린샷 공유. Step 2 대비 예상과 크게 다른 단순한 구조였음 — 기존 추측(Maintainer / Why submit / Additional context 자유서술)은 실제 양식에 존재하지 않음.

## 실제 Step 3 필드 (4개)

| 필드 | 타입 | 추천값 | 근거 |
|------|------|-------|------|
| 지원 플랫폼 (Claude Code ☑ / Cowork ☐) | checkbox | **Claude Code만** | Cowork에서 테스트 안 함. 안내문이 "제출 전 테스트하세요" 명시. |
| 라이선스 유형 | 텍스트 | `MIT` | LICENSE 파일 확인 |
| 개인정보 처리방침 URL | 선택(*없음) | **공란** | claude-forge는 클라이언트측 도구, 서버 PII 처리 없음. 거짓 URL 금지. |
| 이메일 주소 * | 필수 | pre-fill 유지 | Anthropic 계정에서 자동 채워짐 |

**최종 버튼**: "검토 요청 제출" (Submit for review)

## 변경 (+18/-35)

§7 Step 3 섹션을 실제 4-field 구조로 교체. 기존 추측된 자유서술 블록("Why submit?", "Additional context")은 양식에 존재하지 않아 삭제. 해당 내용은 이미 Step 2 "플러그인 설명" 필드와 docs 링크에 반영되어 있음.

## 핵심 판단

**"개인정보 처리방침 URL 공란"이 가장 중요한 결정**. 이 필드는 선택이고, claude-forge가 서버를 운영하지 않는 클라이언트측 도구이므로 존재하지 않는 정책 URL을 기입하면 거짓 정보. `SECURITY.md`는 vulnerability-disclosure 경로이지 PII 처리 방침이 아니므로 대체 불가.

## 검증

- 기존 §7 Step 3 삭제 / 재작성 완료
- 4 필드 모두 추천값 + 근거 문서화
- Markdown 렌더링 유효

🤖 Generated with [Claude Code](https://claude.com/claude-code)