### PR TITLE
fix(settings): tui boolean → string enum (Claude Code v2.1.110+)

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "cleanupPeriodDays": 14,
-  "tui": true,
+  "tui": "fullscreen",
   "disableSkillShellExecution": false,
   "enabledMcpjsonServers": ["playwright", "context7", "jina-reader", "chrome-devtools"],
   "env": {


### PR DESCRIPTION
## Summary
- Claude Code v2.1.110(2026-04-15)부터 `settings.json`의 `tui` 필드가 boolean → string enum (`"default" | "fullscreen"`)으로 변경됨
- `"tui": true` → `"tui": "fullscreen"` 1줄 수정으로 `/doctor` 경고 해소

## 배경
문태윤님(claude-forge 사용자) `/doctor` 경고 리포트 → 원격 우회(`settings.local.json` override) 임시 안내 완료. 본 PR이 머지되면 `forge-update`로 자동 해결.

## 영향
- 새 사용자: 처음부터 깨끗
- 기존 사용자: `forge-update` 1회로 자동 해결

## Test plan
- [x] `settings.json` 1줄 diff 검증
- [x] 스키마 (`json.schemastore.org/claude-code-settings.json`) 호환 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)