### PR TITLE
fix(install.ps1): include cc-chips-custom and scripts dirs

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -251,7 +251,7 @@ function Copy-ConfigFiles {
         New-Item -ItemType Directory -Path $ClaudeDir -Force | Out-Null
     }
 
-    $directories = @("agents", "rules", "commands", "skills", "hooks", "cc-chips")
+    $directories = @("agents", "rules", "commands", "scripts", "skills", "hooks", "cc-chips", "cc-chips-custom")
     foreach ($dir in $directories) {
         $source = Join-Path $RepoDir $dir
         if (Test-Path $source) {
@@ -333,7 +333,7 @@ function Test-Installation {
     Write-Host "설치 확인 중... (Verifying installation)" -ForegroundColor White
     $errors = 0
 
-    $items = @("agents", "rules", "commands", "skills", "cc-chips", "hooks.json", "settings.json")
+    $items = @("agents", "rules", "commands", "scripts", "skills", "cc-chips", "cc-chips-custom", "hooks.json", "settings.json")
     foreach ($item in $items) {
         $path = Join-Path $ClaudeDir $item
         if (Test-Path $path) {


### PR DESCRIPTION
## Summary

- Windows installer was missing two directories that the POSIX installer handles, breaking `statusLine` on a fresh Windows install
- Adds `scripts` and `cc-chips-custom` to both `\$directories` (Copy-ConfigFiles, install.ps1:254) and `\$items` (Test-Installation, install.ps1:336)
- Brings `install.ps1` to parity with `install.sh:282` and `install.sh:575`

Fixes #50.

## Why

`settings.json` declares:

\`\`\`json
"statusLine": { "type": "command", "command": "~/.claude/cc-chips-custom/engine.sh" }
\`\`\`

But `install.ps1` did not copy `cc-chips-custom/` to `~/.claude/`, so the chip status bar fails silently on Windows. `scripts/` (containing `md-to-docx`, `pdf-enhance`) was also dropped on Windows only.

## Test plan

- [x] `.\install.ps1 -Upgrade -DryRun` now reports `would refresh scripts/` and `would refresh cc-chips-custom/`
- [x] After actual install, `~/.claude/cc-chips-custom/engine.sh` exists and statusLine renders
- [ ] Maintainer to verify on a clean Windows VM if desired

## Out of scope

The `apply_cc_chips_custom` overlay step from `install.sh:359` (which also copies `cc-chips-custom/engine.sh` over `cc-chips/engine.sh`) is not ported here — `settings.json` only depends on `~/.claude/cc-chips-custom/engine.sh` existing, so the directory copy alone fixes the user-visible bug. Happy to add the overlay in a follow-up if you'd like full parity.