### PR TITLE
fix: quote argument-hint YAML values so Copilot CLI ≥1.0.65 loads all skills (closes #55)

### DIFF
--- a/commands/explore.md
+++ b/commands/explore.md
@@ -1,7 +1,7 @@
 ---
 allowed-tools: Read, Grep, Glob, Bash(git:*)
 description: 코드베이스를 탐색하여 구조를 파악합니다.
-argument-hint: [경로] [--deps]
+argument-hint: "[경로] [--deps]"
 ---
 
 # /explore - 반복 정제 코드베이스 탐색 (v6)

--- a/commands/forge-update.md
+++ b/commands/forge-update.md
@@ -1,7 +1,7 @@
 ---
 allowed-tools: Read, Glob, Bash(git:*), Bash(jq:*), Bash(readlink:*), Bash(cp:*), Bash(ln:*), Bash(rm:*), Bash(mv:*), Bash(ls:*), Bash(chmod:*), Bash(date:*), Bash(cat:*), Bash(mkdir:*), Bash(diff:*), Bash(wc:*), Bash(grep:*)
 description: Claude Forge 프레임워크를 원격에서 최신 버전으로 업데이트
-argument-hint: [--check-only] [--force]
+argument-hint: "[--check-only] [--force]"
 ---
 
 # /forge-update - Claude Forge 자체 업데이트

--- a/commands/init-project.md
+++ b/commands/init-project.md
@@ -1,7 +1,7 @@
 ---
 allowed-tools: Bash(git:*), Bash(mkdir:*), Read, Write, Glob
 description: 프로젝트 초기 설정 (v6)
-argument-hint: [프로젝트명] [--type next|vite|go|python|rust]
+argument-hint: "[프로젝트명] [--type next|vite|go|python|rust]"
 ---
 
 # /init-project - 프로젝트 초기화 (v6)

--- a/commands/loop-forge.md
+++ b/commands/loop-forge.md
@@ -1,6 +1,6 @@
 ---
 description: Turn a one-line repetitive task into a reusable, self-guarding slash command (loop-forge)
-argument-hint: [one-line description of the task you keep doing by hand]
+argument-hint: "[one-line description of the task you keep doing by hand]"
 ---
 
 # /loop-forge

--- a/commands/next-task.md
+++ b/commands/next-task.md
@@ -1,7 +1,7 @@
 ---
 allowed-tools: Read, Grep, Glob
 description: 다음 작업 추천 (v6)
-argument-hint: [--from-plan]
+argument-hint: "[--from-plan]"
 ---
 
 # /next-task - 다음 Task 시작 준비 (v6)

--- a/commands/orchestrate.md
+++ b/commands/orchestrate.md
@@ -1,7 +1,7 @@
 ---
 allowed-tools: Bash(git:*), Read, Write, Glob, Grep, Task, TeamCreate, TaskCreate, TaskUpdate, TaskList, SendMessage
 description: Agent Teams 기반 병렬 오케스트레이션 (v6)
-argument-hint: [--type feature|bugfix|refactor|review] [--parallel N] [--dry-run]
+argument-hint: "[--type feature|bugfix|refactor|review] [--parallel N] [--dry-run]"
 ---
 
 # /orchestrate - Agent Teams 기반 병렬 오케스트레이션 (v6)

--- a/commands/security-review.md
+++ b/commands/security-review.md
@@ -1,7 +1,7 @@
 ---
 allowed-tools: Bash(npm:*), Bash(npx:*), Bash(pip:*), Bash(cargo:*), Bash(grep:*), Bash(git:*), Read, Glob, Grep
 description: CWE 기반 보안 검토 + STRIDE 위협 모델링 (v6 - effort:max 강제)
-argument-hint: [파일/디렉토리] [--auto] [--quick] [--cwe] [--stride] [--deps] [--report markdown|json]
+argument-hint: "[파일/디렉토리] [--auto] [--quick] [--cwe] [--stride] [--deps] [--report markdown|json]"
 ---
 
 ## Task

--- a/commands/suggest-automation.md
+++ b/commands/suggest-automation.md
@@ -1,7 +1,7 @@
 ---
 allowed-tools: Read, Grep, Glob, Bash(git:*)
 description: 반복 패턴 분석하여 자동화 기회 제안 (주기적 실행 권장)
-argument-hint: [분석할 커밋 수, 기본 50]
+argument-hint: "[분석할 커밋 수, 기본 50]"
 ---
 
 ## Task
@@ -114,7 +114,7 @@ Read 도구로 다음 디렉토리 확인:
 ---
 allowed-tools: [필요한 도구]
 description: [자동 생성된 설명]
-argument-hint: [인자 힌트]
+argument-hint: "[인자 힌트]"
 ---
 
 ## Task

--- a/commands/sync.md
+++ b/commands/sync.md
@@ -1,7 +1,7 @@
 ---
 allowed-tools: Read, Write, Edit, Grep, Glob, Bash(git:*)
 description: git pull + 문서 동기화 통합 (pull → sync-docs v7 순차 실행)
-argument-hint: [--no-pull] [--check-only] [작업설명]
+argument-hint: "[--no-pull] [--check-only] [작업설명]"
 ---
 
 # /sync - Git Pull + 문서 동기화

--- a/commands/verify-loop.md
+++ b/commands/verify-loop.md
@@ -1,7 +1,7 @@
 ---
 allowed-tools: Bash(npm:*), Bash(npx:*), Bash(python:*), Bash(go:*), Bash(cargo:*), Bash(make:*), Bash(git:*), Bash(rm:*), Read, Edit, Grep, Glob
 description: 자동 재검증 루프 (최대 3회 재시도, 실패 시 자동 수정)
-argument-hint: [의도 설명 - handoff.md 없으면 필수] [--max-retries N] [--only build|test|lint]
+argument-hint: "[의도 설명 - handoff.md 없으면 필수] [--max-retries N] [--only build|test|lint]"
 ---
 
 ## Task

--- a/commands/web-checklist.md
+++ b/commands/web-checklist.md
@@ -1,7 +1,7 @@
 ---
 allowed-tools: Read, Write, Grep, Glob, Bash(git:*)
 description: 머지 후 웹 테스트 체크리스트 + 완료 추적 (v6)
-argument-hint: [--auto-from-handoff] [--detailed] [--save] [--status] [--complete ID]
+argument-hint: "[--auto-from-handoff] [--detailed] [--save] [--status] [--complete ID]"
 ---
 
 ## Task

--- a/commands/worktree-cleanup.md
+++ b/commands/worktree-cleanup.md
@@ -1,7 +1,7 @@
 ---
 allowed-tools: Bash(git:*), Read, Grep
 description: PR 완료 후 Git Worktree 정리 (v6)
-argument-hint: [브랜치명 - 생략시 현재 워크트리]
+argument-hint: "[브랜치명 - 생략시 현재 워크트리]"
 ---
 
 ## Task

--- a/commands/worktree-start.md
+++ b/commands/worktree-start.md
@@ -1,7 +1,7 @@
 ---
 allowed-tools: Bash(git:*), Read, Grep
 description: 병렬 개발용 Git Worktree 생성 + 도메인 템플릿 (v6)
-argument-hint: [브랜치명] [--type feature|bugfix|refactor]
+argument-hint: "[브랜치명] [--type feature|bugfix|refactor]"
 ---
 
 ## Task

--- a/skills/loop-forge/tools/examples/batch/claude-command.md
+++ b/skills/loop-forge/tools/examples/batch/claude-command.md
@@ -1,6 +1,6 @@
 ---
 description: Summarize 100 shop reviews into 3 lines each (Batch loop)
-argument-hint: [input file path — blank for reviews.csv]
+argument-hint: "[input file path — blank for reviews.csv]"
 ---
 
 # /review-summary — bulk 3-line review summary (Batch)


### PR DESCRIPTION
Closes #55.

## Summary

Purely mechanical single-character transform to 14 file(s): wrap the value after `argument-hint:` in double quotes so YAML parses it as a **string** instead of a flow-sequence array. Fixes GitHub Copilot CLI ≥ 1.0.65 silently dropping the skill.

```diff
- argument-hint: [foo]
+ argument-hint: "[foo]"
```

Bare `[...]` is YAML flow-sequence syntax → the loader receives `["foo"]` (a list), fails its `str` validation, and rejects the SKILL without an error. Claude Code, VS Code Agent Skills, and every other loader document `argument-hint` as a string; the quoted-string form is what all reference docs show.

## Files (14)

- `commands/next-task.md`
- `commands/sync.md`
- `commands/web-checklist.md`
- `commands/forge-update.md`
- `commands/orchestrate.md`
- `commands/loop-forge.md`
- `commands/suggest-automation.md`
- `commands/init-project.md`
- `commands/verify-loop.md`
- `commands/worktree-cleanup.md`
- `commands/explore.md`
- `commands/worktree-start.md`
- `skills/loop-forge/tools/examples/batch/claude-command.md`
- `commands/security-review.md`

## Verification

- YAML round-trip via `yaml.safe_load` on every changed frontmatter reports `argument-hint` as `str`
- No vulnerable value contained `"` or `\`, so bare double-quote wrapping is safe

## Sources

- [Claude Code slash-commands / frontmatter reference](https://code.claude.com/docs/en/slash-commands) — `argument-hint` documented as a string
- [VS Code Agent Skills docs](https://code.visualstudio.com/docs/agent-customization/agent-skills) — same
