### PR TITLE
fix(commands): make learn.md frontmatter parseable + validate commands in CI

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -204,6 +204,82 @@ jobs:
               sys.exit(1)
           EOF
 
+      # commands/*.md had no frontmatter validation at all, which is why 10 of
+      # 34 commands shipped with frontmatter that no YAML parser can read
+      # (a bare `argument-hint: [a] [b]` is not valid YAML). See #55.
+      - name: Validate commands/*.md frontmatter
+        run: |
+          python3 <<'EOF'
+          import re, sys, yaml
+          from pathlib import Path
+
+          errors = 0
+          checked = 0
+          for md in sorted(Path("commands").glob("*.md")):
+              text = md.read_text()
+              fm = re.match(r'^---\n(.*?)\n---\n', text, re.DOTALL)
+              if not fm:
+                  # Not every command carries frontmatter; that is allowed.
+                  print(f"::warning file={md}::no YAML frontmatter (skipped)")
+                  continue
+              checked += 1
+              try:
+                  data = yaml.safe_load(fm.group(1))
+              except yaml.YAMLError as e:
+                  detail = str(e).replace("\n", " ")[:200]
+                  print(f"::error file={md}::frontmatter is not valid YAML: {detail}")
+                  errors += 1
+                  continue
+              if not isinstance(data, dict):
+                  print(f"::error file={md}::frontmatter is not a mapping")
+                  errors += 1
+                  continue
+              # `argument-hint: [a] [b]` parses as a list (or fails outright).
+              # Every loader documents it as a string; Copilot CLI >= 1.0.65
+              # silently drops the command when it is not one.
+              hint = data.get("argument-hint")
+              if hint is not None and not isinstance(hint, str):
+                  print(f"::error file={md}::argument-hint must be a string, got "
+                        f"{type(hint).__name__} — wrap the value in quotes")
+                  errors += 1
+                  continue
+              print(f"OK: {md}")
+
+          print(f"checked {checked} command(s) with frontmatter")
+          if errors:
+              sys.exit(1)
+          EOF
+
+      - name: Validate argument-hint is a string in skills
+        run: |
+          python3 <<'EOF'
+          import re, sys, yaml
+          from pathlib import Path
+
+          errors = 0
+          for md in sorted(Path("skills").rglob("*.md")):
+              fm = re.match(r'^---\n(.*?)\n---\n', md.read_text(), re.DOTALL)
+              if not fm:
+                  continue
+              try:
+                  data = yaml.safe_load(fm.group(1))
+              except yaml.YAMLError as e:
+                  detail = str(e).replace("\n", " ")[:200]
+                  print(f"::error file={md}::frontmatter is not valid YAML: {detail}")
+                  errors += 1
+                  continue
+              if not isinstance(data, dict):
+                  continue
+              hint = data.get("argument-hint")
+              if hint is not None and not isinstance(hint, str):
+                  print(f"::error file={md}::argument-hint must be a string, got "
+                        f"{type(hint).__name__} — wrap the value in quotes")
+                  errors += 1
+          if errors:
+              sys.exit(1)
+          print("OK: every skill argument-hint is a string")
+          EOF
+
   installer:
     name: Installer Dry-Run
     strategy:

--- a/commands/learn.md
+++ b/commands/learn.md
@@ -1,7 +1,7 @@
 ---
 allowed-tools: Bash(git:*), Read, Edit, Write, Grep, Glob
 description: 교훈 기록 + 자동화 제안 (v6 - suggest-automation 통합)
-argument-hint: ["교훈 내용"] [--from-error] [--from-session] [--suggest] [--list] [--edit N] [--remove N]
+argument-hint: '["교훈 내용"] [--from-error] [--from-session] [--suggest] [--list] [--edit N] [--remove N]'
 ---
 
 # /learn - 교훈 기록 + 자동화 제안 (v6)

--- a/docs/STRUCTURE-VALIDATION.md
+++ b/docs/STRUCTURE-VALIDATION.md
@@ -251,13 +251,13 @@ These are not auto-loaded by Claude Code's plugin system but are used by the ins
 | Component | Status | Count | Notes |
 |-----------|--------|-------|-------|
 | `.claude-plugin/plugin.json` | PASS | 1 | Extra fields are harmless |
-| Skills (`SKILL.md`) | PASS | 15 | All correctly structured |
+| Skills (`SKILL.md`) | PASS | 26 | All correctly structured |
 | Hooks (shell scripts) | PASS | 15 | Loaded via `settings.json` |
 | `hooks.json` | PASS | 0 | Removed in v3.1.1; wiring lives in `settings.json` |
 | Agents | PASS | 11 | Standard frontmatter format |
-| Commands | PASS | 40 | 3 without frontmatter |
+| Commands | PASS | 34 | 31 with frontmatter (all valid YAML, CI-enforced), 3 without |
 | MCP config | WARNING | 1 | Uses `mcp-servers.json` instead of `.mcp.json` |
-| Rules | PASS | 9 | Auto-loaded by plugin system |
+| Rules | PASS | 10 | Auto-loaded by plugin system |
 | `settings.json` | PASS | 1 | Requires install script merge |
 
 ### Action Items for Official Marketplace Submission

--- a/docs/STRUCTURE-VALIDATION.md
+++ b/docs/STRUCTURE-VALIDATION.md
@@ -53,30 +53,41 @@ Official `plugin.json` uses minimal fields (`name`, `description`, `author`). Cl
 
 ## 2. Skills Directory — PASS
 
-All 15 skills have correctly structured `SKILL.md` files:
+All 26 skills have correctly structured `SKILL.md` files:
 
 ```
 skills/
+├── blind-spot-pass/SKILL.md
 ├── build-system/SKILL.md
 ├── cache-components/SKILL.md
 ├── cc-dev-agent/SKILL.md
 ├── continuous-learning-v2/SKILL.md
+├── debugging-strategies/SKILL.md
+├── dependency-upgrade/SKILL.md
 ├── eval-harness/SKILL.md
+├── evaluating-code-models/SKILL.md
+├── evaluating-llms-harness/SKILL.md
+├── extract-errors/SKILL.md
 ├── frontend-code-review/SKILL.md
+├── loop-forge/SKILL.md
 ├── manage-skills/SKILL.md
 ├── prompts-chat/SKILL.md
+├── security-compliance/SKILL.md
 ├── security-pipeline/SKILL.md
 ├── session-wrap/SKILL.md
 ├── skill-factory/SKILL.md
 ├── strategic-compact/SKILL.md
+├── stride-analysis-patterns/SKILL.md
+├── summarize/SKILL.md
 ├── team-orchestrator/SKILL.md
+├── using-superpowers/SKILL.md
 ├── verification-engine/SKILL.md
 └── verify-implementation/SKILL.md
 ```
 
 | Check | Status | Details |
 |-------|--------|---------|
-| `skills/*/SKILL.md` pattern | PASS | All 15 skills follow `skills/{name}/SKILL.md` |
+| `skills/*/SKILL.md` pattern | PASS | All 26 skills follow `skills/{name}/SKILL.md` |
 | Frontmatter present | PASS | Checked `build-system` and `session-wrap` — both have `---` frontmatter with `name`, `description` |
 | Matches official pattern | PASS | Official example: `skills/example-skill/SKILL.md` |
 
@@ -147,13 +158,13 @@ agents/
 
 ## 5. Commands — PASS
 
-40 command files in `commands/`:
+34 command files in `commands/`:
 
 | Check | Status | Details |
 |-------|--------|---------|
-| Files present | PASS | 40 `.md` command files |
-| Frontmatter | PASS | Most commands have `---` YAML frontmatter with `description` and `allowed-tools` |
-| Some without frontmatter | WARNING | `build-fix.md`, `refactor-clean.md`, `eval.md` start with `#` heading instead of `---`. These may not register as slash commands properly |
+| Files present | PASS | 34 `.md` command files |
+| Frontmatter | PASS | 31 commands have `---` YAML frontmatter; all parse as valid YAML and any `argument-hint` is a string (enforced by CI since v3.1.1) |
+| Some without frontmatter | WARNING | `test-coverage.md`, `update-codemaps.md`, `update-docs.md` start with a `#` heading instead of `---`. These may not register as slash commands properly |
 
 ---
 
@@ -209,7 +220,7 @@ agents/
 
 ## 8. Rules — PASS
 
-9 rule files in `rules/`:
+10 rule files in `rules/`:
 
 ```
 rules/
@@ -221,12 +232,13 @@ rules/
 ├── interaction.md
 ├── security.md
 ├── testing.md
+├── unknowns-lens.md
 └── verification.md
 ```
 
 | Check | Status | Details |
 |-------|--------|---------|
-| Files present | PASS | 9 `.md` rule files |
+| Files present | PASS | 10 `.md` rule files |
 | Claude Code support | PASS | Rules in plugin `rules/` directory are auto-loaded by Claude Code |
 
 ---


### PR DESCRIPTION
Follow-up to #56 (merged) — completes #55.

## What #56 missed

#56 quoted `argument-hint` in 14 files. `commands/learn.md` was not one of them, and it could not have used the same fix, because its value already contains double quotes:

```yaml
argument-hint: ["교훈 내용"] [--from-error] [--from-session] [--suggest] [--list] [--edit N] [--remove N]
```

Wrapping that in double quotes is still invalid YAML. It needs single quotes, which is what this PR does.

## The problem was wider than #55 described

#55 reported that `argument-hint` parses as a list. That is true for some files, but on **10 of 34 commands the entire frontmatter block failed to parse** — a bare `[a] [b]` is not valid YAML at all:

```
argument-hint: [경로] [--deps]
                      ^ expected <block end>, but found '['
```

#56 fixed 9 of those 10. `learn.md` was the last one. After this PR, all 74 frontmatter blocks in the repo (commands + skills + agents) parse cleanly.

## Why nothing caught it

`validate.yml` validates frontmatter for `agents/*.md` and `skills/*/SKILL.md`, but has never looked at `commands/*.md`. Ten commands shipped unparseable frontmatter through every CI run.

Two steps added to the `frontmatter` job:

1. **`commands/*.md`** — frontmatter must parse as a YAML mapping, and `argument-hint` must be a string when present. Commands with no frontmatter remain allowed (3 of them: `test-coverage.md`, `update-codemaps.md`, `update-docs.md`), reported as warnings.
2. **`skills/**/*.md`** — `argument-hint` must be a string. This covers the example command under `skills/loop-forge/tools/examples/`, which `skills/*/SKILL.md` globbing does not reach.

## Verification

Ran both new steps locally against the real tree and against deliberately broken copies:

| Case | Expected | Result |
|---|---|---|
| Fixed tree | pass | `checked 31 command(s) with frontmatter`, exit 0 |
| `learn.md` reverted to pre-fix | fail | `::error ... frontmatter is not valid YAML`, exit 1 |
| Injected `argument-hint: [--from-plan]` | fail | `::error ... must be a string, got list`, exit 1 |

Repo-wide sweep after the fix: 74 frontmatter blocks, 0 parse failures, 0 non-string `argument-hint`.

## Also

Refreshed the `STRUCTURE-VALIDATION.md` summary counts, which had drifted from the actual tree (skills 15 → 26, commands 40 → 34, rules 9 → 10). Measured, not guessed.