### PR TITLE
fix(setup): don't abort install when work-tracker-sync.sh is absent

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -650,12 +650,15 @@ write_meta() {
     echo -e "  ${GREEN}✓${NC} .forge-meta.json"
 }
 
-# 11. Install work tracker (Supabase sync)
+# 11. Install work tracker (local usage log; remote sync is opt-in)
 install_work_tracker() {
     local wt_script="$REPO_DIR/setup/work-tracker-install.sh"
     if [ -f "$wt_script" ]; then
         echo ""
-        read -p "Install Work Tracker (Claude Code usage tracking → Supabase)? (y/n) " -n 1 -r
+        # Remote sync needs scripts/work-tracker-sync.sh, which is not shipped: the
+        # backend differs per user. Without it the hooks still log locally to
+        # ~/.claude/work-log/buffer.jsonl, so do not promise a sync we cannot install.
+        read -p "Install Work Tracker (logs Claude Code usage to ~/.claude/work-log)? (y/n) " -n 1 -r
         echo ""
         if [[ $REPLY =~ ^[Yy]$ ]]; then
             REPO_DIR="$REPO_DIR" bash "$wt_script"

--- a/setup/work-tracker-install.sh
+++ b/setup/work-tracker-install.sh
@@ -19,17 +19,25 @@ echo ""
 echo "Work Tracker 설치"
 echo "================="
 
+# work-tracker-sync.sh는 **선택 구성요소**다. 동기화 대상(백엔드)이 사용자마다 달라
+# claude-forge는 이 스크립트를 배포하지 않는다. 없어도 훅 3종이
+# ~/.claude/work-log/buffer.jsonl에 로컬 기록을 계속하므로 추적 자체는 동작한다.
+# (#6: 예전에는 이 파일이 없으면 `set -e` + `return 1`로 설치 전체가 중단됐다.)
+SYNC_SRC="$REPO_DIR/scripts/work-tracker-sync.sh"
+HAS_SYNC=0
+[ -f "$SYNC_SRC" ] && HAS_SYNC=1
+
 # 0. 이미 설치 완료 확인 (빠른 스킵)
 quick_check() {
     [ -d "$CLAUDE_DIR/work-log" ] && \
-    [ -f "$CLAUDE_DIR/scripts/work-tracker-sync.sh" ] && \
     [ -f "$CLAUDE_DIR/hooks/work-tracker-prompt.sh" ] && \
-    { [[ "$OSTYPE" != "darwin"* ]] || launchctl list 2>/dev/null | grep -q "work-tracker"; }
+    { [ "$HAS_SYNC" -eq 0 ] || [ -f "$CLAUDE_DIR/scripts/work-tracker-sync.sh" ]; } && \
+    { [ "$HAS_SYNC" -eq 0 ] || [[ "$OSTYPE" != "darwin"* ]] || launchctl list 2>/dev/null | grep -q "work-tracker"; }
 }
 
 if quick_check; then
     # sync 스크립트 버전 비교 (업데이트 필요 시에만 재설치)
-    if diff -q "$REPO_DIR/scripts/work-tracker-sync.sh" "$CLAUDE_DIR/scripts/work-tracker-sync.sh" >/dev/null 2>&1; then
+    if [ "$HAS_SYNC" -eq 0 ] || diff -q "$SYNC_SRC" "$CLAUDE_DIR/scripts/work-tracker-sync.sh" >/dev/null 2>&1; then
         echo -e "  ${GREEN}✓${NC} Work Tracker 이미 설치됨 (최신)"
         return 0 2>/dev/null || exit 0
     else
@@ -49,12 +57,13 @@ setup_worklog_dir() {
 # 2. sync 스크립트 복사
 install_sync_script() {
     echo "  sync 스크립트 설치..."
-    local src="$REPO_DIR/scripts/work-tracker-sync.sh"
+    local src="$SYNC_SRC"
     local dst="$CLAUDE_DIR/scripts/work-tracker-sync.sh"
 
-    if [ ! -f "$src" ]; then
-        echo -e "  ${RED}✗${NC} work-tracker-sync.sh 소스 없음"
-        return 1
+    if [ "$HAS_SYNC" -eq 0 ]; then
+        echo -e "  ${YELLOW}!${NC} 원격 동기화 생략 (선택 구성요소, 로컬 기록은 정상 동작)"
+        echo "    필요하면 scripts/work-tracker-sync.sh를 직접 두고 다시 실행하세요."
+        return 0
     fi
 
     mkdir -p "$CLAUDE_DIR/scripts"
@@ -65,6 +74,13 @@ install_sync_script() {
 
 # 3. LaunchAgent 설치 (macOS only)
 install_launchagent() {
+    # sync 스크립트가 없으면 타이머를 걸지 않는다. 걸어두면 1분마다 없는 파일을 실행하려다
+    # 실패하는 LaunchAgent가 남아, 설치가 "성공"한 것처럼 보이면서 로그만 더럽힌다.
+    if [ "$HAS_SYNC" -eq 0 ]; then
+        echo -e "  ${YELLOW}!${NC} LaunchAgent 건너뜀 (동기화할 sync 스크립트 없음)"
+        return 0
+    fi
+
     if [[ "$OSTYPE" != "darwin"* ]]; then
         echo -e "  ${YELLOW}!${NC} macOS가 아님 — LaunchAgent 건너뜀 (cron 수동 설정 필요)"
         return 0
@@ -149,9 +165,11 @@ verify_install() {
         fi
     done
 
-    # sync 스크립트
+    # sync 스크립트 (선택 구성요소 — 미배포 상태는 실패가 아니다)
     if [ -f "$CLAUDE_DIR/scripts/work-tracker-sync.sh" ] && [ -x "$CLAUDE_DIR/scripts/work-tracker-sync.sh" ]; then
         echo -e "  ${GREEN}✓${NC} scripts/work-tracker-sync.sh"
+    elif [ "$HAS_SYNC" -eq 0 ]; then
+        echo -e "  ${YELLOW}!${NC} scripts/work-tracker-sync.sh (선택 — 원격 동기화 미사용)"
     else
         echo -e "  ${RED}✗${NC} scripts/work-tracker-sync.sh"
         ((errors++))
@@ -182,8 +200,9 @@ print('ok' if all(e in hooks for e in events) else 'missing')
         fi
     fi
 
-    # LaunchAgent (macOS)
-    if [[ "$OSTYPE" == "darwin"* ]]; then
+    # LaunchAgent (macOS). sync를 설치하지 않았으면 이 설치와 무관하므로 보고하지 않는다
+    # (남아 있는 다른 work-tracker 항목을 "이번 설치 결과"로 오인하게 만든다).
+    if [[ "$OSTYPE" == "darwin"* ]] && [ "$HAS_SYNC" -eq 1 ]; then
         if launchctl list 2>/dev/null | grep -q "work-tracker"; then
             echo -e "  ${GREEN}✓${NC} LaunchAgent 실행 중"
         else


### PR DESCRIPTION
Closes #6.

## The bug

Answering `y` to the Work Tracker prompt in `install.sh` ended here:

```
sync 스크립트 설치...
✗ work-tracker-sync.sh 소스 없음
```

`setup/work-tracker-install.sh:52` referenced `$REPO_DIR/scripts/work-tracker-sync.sh` and returned 1 when missing. Because that script has `set -e` at the top, the return aborted the entire installer — `install_launchagent` and `verify_install` never ran.

Reproduced on `main`:

| | before | after |
|---|---|---|
| exit | aborted at "소스 없음" | `Work Tracker 설치 완료!`, rc 0 |
| LaunchAgent | (unreached) | not registered, correctly |

## Why the file is not simply added

The reference implementation of `work-tracker-sync.sh` is bound to one specific Supabase project — a hardcoded project endpoint plus `SUPABASE_SERVICE_ROLE_KEY` / `SUPABASE_AUTH_TOKEN` references across ~49 lines. Publishing it would expose a backend and would be useless to anyone else, since the sync target differs per user.

So the honest fix is to make remote sync opt-in rather than to pretend to ship it.

## What changes

Without `scripts/work-tracker-sync.sh` present:

- **Install succeeds.** The three hooks still log to `~/.claude/work-log/buffer.jsonl`, which is the part that works standalone.
- **No LaunchAgent is registered.** Previously the plist was written regardless, leaving a timer that tried to exec a nonexistent script every 60 seconds — a silent, permanent failure that looked like a successful install.
- **Verification reports it as informational**, not an error, and no longer prints LaunchAgent state that this install did not create (it was reporting a leftover `work-tracker` entry from an unrelated setup as if it were this one).
- **`quick_check` no longer requires the file**, so repeat runs stop trying to reinstall.

With the file present, behaviour is unchanged.

Also fixed the `install.sh` prompt, which advertised `usage tracking → Supabase` while being unable to install any sync at all.

## Verification

Ran the installer under an isolated `HOME` in both configurations:

- **sync absent** — completes with rc 0, `Library/LaunchAgents` stays empty
- **sync present** (stub placed in `scripts/`) — installs it and proceeds into the LaunchAgent path exactly as before

Plus `bash -n` on both scripts and the CI installer job locally (`./install.sh --upgrade --dry-run` → `v3.0 core MCP entries present (3/3)`).