### PR TITLE
feat: add optional Parallel Search MCP server

### DIFF
--- a/mcp-servers.optional.json
+++ b/mcp-servers.optional.json
@@ -19,7 +19,7 @@
       "type": "http",
       "url": "https://search.parallel.ai/mcp",
       "description": "Parallel Search MCP for web search and URL content retrieval. Queries and requested URLs are sent to Parallel.ai.",
-      "when_to_use": "When you want an optional no-account, no-API-key search and fetch alternative alongside built-in WebSearch and other providers."
+      "when_to_use": "Web search and URL content retrieval without an API key. Useful when you don't want to manage search-provider credentials."
     },
     "github": {
       "type": "stdio",

--- a/mcp-servers.optional.json
+++ b/mcp-servers.optional.json
@@ -15,6 +15,12 @@
       "description": "Exa AI web search and company research.",
       "when_to_use": "When built-in WebSearch is insufficient (company/people deep research, semantic search with filters)."
     },
+    "parallel-search": {
+      "type": "http",
+      "url": "https://search.parallel.ai/mcp",
+      "description": "Parallel Search MCP for web search and URL content retrieval. Queries and requested URLs are sent to Parallel.ai.",
+      "when_to_use": "When you want an optional no-account, no-API-key search and fetch alternative alongside built-in WebSearch and other providers."
+    },
     "github": {
       "type": "stdio",
       "command": "npx",


### PR DESCRIPTION
## Description

Adds Parallel Search MCP next to Exa in the existing optional server catalog. Users who manually copy the entry into their active configuration can use web search and URL content retrieval without an account or API key; queries and requested URLs are sent to Parallel.ai.

The active MCP configuration, built-in WebSearch guidance, existing providers, credentials, and defaults remain unchanged.

Validation:
- `python3 -m json.tool mcp-servers.optional.json`: passed.
- Compared the catalog with the baseline after removing only `parallel-search`: passed, confirming all incumbent entries are unchanged.
- Verified `mcp-servers.json` is byte-identical to the baseline and the diff changes only `mcp-servers.optional.json`: passed.
- `git diff --check`: passed.

## Type of Change
- [ ] New agent/command/skill
- [ ] Bug fix
- [ ] Documentation update
- [x] Configuration change
- [ ] Other (please describe)

## Checklist
- [ ] Tested on macOS/Linux
- [ ] Updated relevant documentation
- [x] No hardcoded secrets
- [x] Follows existing code style
- [ ] ShellCheck passes (for .sh files)

Disclosure: I work at Parallel.ai, which operates this MCP endpoint.