### PR TITLE
release: v4.2.0 — session-time-report (22nd hook): resume-aware end-of-session summary

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "claude-forge",
-  "version": "4.1.0",
-  "description": "oh-my-zsh for Claude Code — 16 agents, 35 commands, 33 skills, 21 hooks + 9 opt-in examples (21 events), 14 rules, 4 MCP in one install",
+  "version": "4.2.0",
+  "description": "oh-my-zsh for Claude Code — 16 agents, 35 commands, 33 skills, 22 hooks + 9 opt-in examples (21 events), 14 rules, 4 MCP in one install",
   "owner": {
     "name": "Sangrok Jung",
     "url": "https://github.com/sangrokjung"
@@ -10,8 +10,8 @@
   "plugins": [
     {
       "name": "claude-forge",
-      "description": "Production-grade development environment for Claude Code with 16 specialized agents, 35 slash commands, 33 skills, 21 hooks + 9 opt-in examples (21 events), 14 rules, and 4 MCP servers (playwright, context7, jina-reader, chrome-devtools pinned at 0.23.0). Includes TDD workflow, security review, code review, architecture analysis, build error resolution, Chrome DevTools Lighthouse / Core Web Vitals audits, and an adversarial verification loop (maker≠checker) with unattended API-error auto-resume, session relay, and Korean prose quality guardrails.",
-      "version": "4.1.0",
+      "description": "Production-grade development environment for Claude Code with 16 specialized agents, 35 slash commands, 33 skills, 22 hooks + 9 opt-in examples (21 events), 14 rules, and 4 MCP servers (playwright, context7, jina-reader, chrome-devtools pinned at 0.23.0). Includes TDD workflow, security review, code review, architecture analysis, build error resolution, Chrome DevTools Lighthouse / Core Web Vitals audits, and an adversarial verification loop (maker≠checker) with unattended API-error auto-resume, session relay, and Korean prose quality guardrails.",
+      "version": "4.2.0",
       "author": {
         "name": "Sangrok Jung",
         "url": "https://github.com/sangrokjung"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-forge",
-  "version": "4.1.0",
-  "description": "oh-my-zsh for Claude Code — 16 agents, 35 commands, 33 skills, 21 hooks + 9 examples (21 events), 14 rules, 4 MCP (minimal: playwright, context7, jina-reader, chrome-devtools@0.23.0). Adversarial verification loop (maker≠checker), unattended API-error auto-resume, session relay, and Korean prose quality guardrails. One-line install: curl -fsSL https://raw.githubusercontent.com/sangrokjung/claude-forge/main/install.sh | bash",
+  "version": "4.2.0",
+  "description": "oh-my-zsh for Claude Code — 16 agents, 35 commands, 33 skills, 22 hooks + 9 examples (21 events), 14 rules, 4 MCP (minimal: playwright, context7, jina-reader, chrome-devtools@0.23.0). Adversarial verification loop (maker≠checker), unattended API-error auto-resume, session relay, and Korean prose quality guardrails. One-line install: curl -fsSL https://raw.githubusercontent.com/sangrokjung/claude-forge/main/install.sh | bash",
   "author": {
     "name": "Sangrok Jung",
     "url": "https://github.com/sangrokjung"
@@ -20,7 +20,7 @@
     "security",
     "automation",
     "oh-my-zsh",
-    "hooks-21",
+    "hooks-22",
     "skills-commands-hybrid",
     "mcp-minimal",
     "adversarial-review",

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -502,10 +502,14 @@ jobs:
           errors = checked = 0
           for command in commands:
               # settings.json addresses hooks by their installed location;
-              # ~/.claude/<x> is the repo's <x>.
-              if not command.startswith("~/.claude/"):
+              # ~/.claude/<x> is the repo's <x>. Strip any inline NAME=value
+              # prefix and trailing arguments first: reading the raw string as a
+              # path made every env-prefixed entry skip this check silently.
+              words = command.split()
+              script = next((w for w in words if "=" not in w.split("/")[0]), "")
+              if not script.startswith("~/.claude/"):
                   continue
-              path = command[len("~/.claude/"):]
+              path = script[len("~/.claude/"):]
               mode = modes.get(path)
               if mode is None:
                   print(f"::error file=settings.json::wired hook not tracked in this repo: {path}")

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -569,7 +569,8 @@ jobs:
           for suite in \
               scripts/tests/test_hook_guard.sh \
               scripts/tests/test_auto_resume_classify.sh \
-              scripts/tests/test_s5_hooks.sh; do
+              scripts/tests/test_s5_hooks.sh \
+              scripts/tests/test_session_time_report.sh; do
             echo "::group::${suite}"
             bash "$suite"
             echo "::endgroup::"

--- a/README.ko.md
+++ b/README.ko.md
@@ -34,6 +34,10 @@
   <a href="README.md">English</a>
 </p>
 
+> ⏱️ **v4.2.0 (2026년 9월, 최신)**: **session-time-report**(22번째 훅)를 추가했어요. 세션이 닫힐 때 시간을 재두고, 다음에 세션을 열면 몇 시에 끝났는지, 실제로 얼마나 걸렸는지, 프롬프트와 도구를 얼마나 썼고 파일을 몇 개 고쳤는지 한 줄로 알려줘요. 며칠 뒤에 이어서 연 세션이라도 전체 경과가 아니라 이번에 앉아 있던 시간만 보여줍니다. 기록은 `~/.claude/work-log/`에 남아요.
+>
+> 📉 **v4.1.0 (2026년 8월)**: **harness-diet**(33번째 스킬) 추가. 항상 로딩되는 컨텍스트(CLAUDE.md + rules)를 실측하고, 거버넌스를 잃지 않으면서 예산 안으로 줄여줘요.
+>
 > 🛡️ **v4.0.0 (2026년 8월)**: 가장 큰 변화는 **적대적 검증 루프(adversarial verification loop)**예요. 코드를 바꿀 때마다, 그 코드를 짜지 않았고 짠 사람의 생각 흐름도 모르는 독립 리뷰어(`adversarial-reviewer`)가 따로 검증해요. "작성자와 검증자는 다른 사람이어야 한다"(maker≠checker)는 원칙이고, 검증자가 `APPROVE`를 낼 때까지 반복해요. 이론이 아니라 실제로 v4.0을 만드는 동안 이 루프가 대표 유지자 본인의 PR(#58, #61)에서 진짜 결함 3건을 잡아냈어요. 자기 자신의 회귀를 통과시키던 CI 검사 하나, 그 검사를 고친 수정본에 똑같은 구멍이 한 단계 더 숨어 있던 것 하나, 그리고 1년 전 릴리스에 조용히 묶여있던 의존성 상한 하나였죠. 실제 검증 기록은 [`docs/VERIFICATION-LOOP.md`](docs/VERIFICATION-LOOP.md)에 있어요. 그 외에 **신뢰성 패키지**도 넣었어요. API 오류가 나면 세션을 스스로 재개하는 무인 자동 복구, `/compact` 이후에도 이어지는 세션 릴레이, 같은 파일을 계속 고치는 걸 감지하는 무한루프 가드, 옵트인 pre-commit 시크릿 가드가 들어있고, 배선 가이드는 [`docs/RELIABILITY.md`](docs/RELIABILITY.md)에 있어요. **디버깅 에스컬레이션 체인**(`systematic-debugger` → `rca-debugger` → `escalation-fixer`), **작업 난이도 자동 분류**(`/workflow-classify`가 S/M/L/XL로 작업 크기를 매기고 문서화·검증 강도를 그에 맞춰요), **한국어 산문 품질 가드레일**(사후 윤문이 아니라 처음 쓸 때부터 번역투·AI 관용구를 피해요. 아래 별도 섹션 참고)도 함께 담았어요. 에이전트 16개, 커맨드 35개, 스킬 32개, 훅 21개, 규칙 14개. 상세: [MIGRATION.ko.md](MIGRATION.ko.md)
 >
 > 🔧 **v3.1.1 핫픽스 (2026년 8월)**: 플러그인 설치 시 아무것도 안 뜨던 문제를 고쳤어요(`Hook load failed: expected record, received undefined`). `/plugin install claude-forge` 후 `✘ failed to load`가 뜨고 스킬·에이전트·커맨드가 하나도 안 보였다면 3.1.1로 올리시면 됩니다. 윈도우 `install.ps1`이 statusLine과 `scripts/`를 복사하지 않던 문제도 함께 해결했어요. 관련: [#52](https://github.com/sangrokjung/claude-forge/issues/52) · [#57](https://github.com/sangrokjung/claude-forge/issues/57) · [#50](https://github.com/sangrokjung/claude-forge/issues/50)
@@ -50,7 +54,7 @@
 
 ## 이게 뭔가요?
 
-**Claude Code**(AI 코딩 조수)를 혼자 쓰면 기본기만 할 줄 아는 신입 직원과 같아요. **Claude Forge**는 그 신입에게 장비 풀세트(전문 비서 16명, 단축버튼 35개, 안전장치 21개 등)를 한 번에 장착해 줘요.
+**Claude Code**(AI 코딩 조수)를 혼자 쓰면 기본기만 할 줄 아는 신입 직원과 같아요. **Claude Forge**는 그 신입에게 장비 풀세트(전문 비서 16명, 단축버튼 35개, 안전장치 22개 등)를 한 번에 장착해 줘요.
 
 > 마치 터미널(명령창)을 꾸며주는 oh-my-zsh처럼, Claude Forge는 AI 코딩 조수를 파워 유저 도구로 업그레이드해요.
 
@@ -61,7 +65,7 @@
 | **에이전트**(agents) | 16개 | 분야별 전문 비서. 기획, 테스트, 보안검토, 아키텍처(시스템 설계), 적대적 검증 등 |
 | **커맨드**(commands) | 35개 | 자주 쓰는 작업 단축버튼. `/plan`(계획), `/tdd`(테스트) 등 |
 | **스킬**(skills) | 33개 | AI가 익혀둔 작업 절차. 루프 자동화, 팀 오케스트레이션, 적대적 검증 루프 등 |
-| **훅**(hooks) | 21 + 예제 9개 | 자동 안전점검. 위험한 명령 차단, API 키 유출 방지, API 오류 자동 복구 등 |
+| **훅**(hooks) | 22 + 예제 9개 | 자동 안전점검. 위험한 명령 차단, API 키 유출 방지, API 오류 자동 복구, 세션 종료 리포트 등 |
 | **규칙**(rules) | 14개 | AI가 따르는 행동 지침. 코딩 스타일, 보안, 깃 워크플로우, 검증 루프 발동 조건 등 |
 | **MCP**(외부 도구 연결) | 4개 | 브라우저 자동화, 문서 검색, 웹 읽기, 크롬 개발자 도구 |
 
@@ -114,7 +118,7 @@ Claude Code 세션 안에서 두 줄 입력:
 | 커맨드 (35개)          | ✅ | ✅ |
 | 스킬 (33개)            | ⚠️ 일부만                  | ✅ |
 | 에이전트 (16개)        | ❌ | ✅ |
-| 훅 (21개 + 예제 9개)   | ❌ | ✅ |
+| 훅 (22개 + 예제 9개)   | ❌ | ✅ |
 | 규칙 (14개)             | ❌ | ✅ |
 | MCP 서버 (4개)         | ❌ | ✅ |
 | 상태바 (CC CHIPS)      | ❌ | ✅ (선택) |
@@ -223,7 +227,7 @@ cd claude-forge && ./install.sh
 
 ---
 
-### 훅(hooks): 자동 안전점검 21개
+### 훅(hooks): 자동 안전점검 22개
 
 항상 켜져 있는 보안 6겹:
 
@@ -252,7 +256,7 @@ cd claude-forge && ./install.sh
 지정한 git 저장소의 커밋을 보호하는 독립 설치형 스크립트예요.
 
 <details>
-<summary>유틸리티 훅 9개 + Opt-in 예제 9개</summary>
+<summary>유틸리티 훅 10개 + Opt-in 예제 9개</summary>
 
 **유틸리티 훅 (항상 켜짐)**:
 
@@ -267,6 +271,21 @@ cd claude-forge && ./install.sh
 | `work-tracker-prompt.sh` | 작업 추적 프롬프트 |
 | `work-tracker-stop.sh` | 작업 추적 종료 |
 | `work-tracker-tool.sh` | 작업 추적 도구 |
+| `session-time-report.sh` | 세션 종료 시각·소요 시간·프롬프트/도구/변경 파일 수를 재고, 다음 세션 시작 때 알려줌 |
+
+**세션 종료 리포트**: `session-time-report.sh`는 세션이 닫힐 때 시간을 재두고, 다음에 세션을 열 때 이렇게 알려줘요.
+
+```
+[Claude Forge] 직전 세션 종료 21:34 KST
+소요 2h 17m · 프롬프트 18 · 도구 143 · 변경 파일 9
+로그: ~/.claude/work-log/session-time-<session_id>.json
+```
+
+왜 두 이벤트에 걸어뒀냐면, 숫자가 만들어지는 곳과 말을 걸 수 있는 곳이 달라서예요. Claude Code는 `SessionEnd` 훅의 출력을 그 훅이 **실패했을 때만** 전달하기 때문에, 정상적으로 끝난 리포트는 그냥 버려집니다. 반면 `SessionStart`는 화면에 닿는 통로죠. 그래서 같은 스크립트가 나갈 때 재고 들어올 때 한 번 알려주는 구조로 배선했어요.
+
+소요 시간은 재개를 감안해서 계산해요. `--continue`로 며칠 뒤에 다시 연 세션은 처음부터 끝까지 재면 수백 시간이 나오는데, 그건 실제로 일한 시간이 아니죠. 그래서 오래 비어 있던 구간을 기준으로 타임라인을 끊고 마지막 구간만 헤드라인에 씁니다. 재개한 세션이면 뒤에 `(재개 3회, 누적 9h 40m)`을 덧붙여요.
+
+끄고 싶으면 `FORGE_SESSION_TIME_REPORT=0`, 구간을 나누는 공백 기준은 `FORGE_SESSION_GAP_MIN`(기본 60분), 표시 언어는 `FORGE_SESSION_REPORT_LANG`(`en`/`ko`, 기본은 `LANG` 자동 감지)으로 조정합니다. 매 세션 기록이 `~/.claude/work-log/session-times.jsonl`에도 쌓이고, 아직 안 보여준 리포트는 `~/.claude/work-log/.session-time-pending.json`에서 다음 세션을 기다려요.
 
 **Opt-in 예제 (직접 활성화 가능)**:
 
@@ -716,14 +735,14 @@ graph TB
 
 ```
 claude-forge/
-  ├── .claude-plugin/            플러그인 매니페스트 (4.1.0)
+  ├── .claude-plugin/            플러그인 매니페스트 (4.2.0)
   ├── .github/workflows/         CI 검증
   ├── agents/                    에이전트 정의 (16 .md, frontmatter v2)
   ├── cc-chips/                  상태바 서브모듈
   ├── cc-chips-custom/           커스텀 상태바 오버레이
   ├── commands/                  슬래시 커맨드 (35 .md, 8개는 skills/로 이동)
   ├── docs/                      스크린샷, 다이어그램, 정책 문서 (RELIABILITY.md·VERIFICATION-LOOP.md 포함)
-  ├── hooks/                     이벤트 기반 스크립트 (21)
+  ├── hooks/                     이벤트 기반 스크립트 (22)
   │   └── examples/              21 lifecycle 이벤트 샘플 opt-in (9)
   ├── knowledge/                 지식 베이스
   ├── libs/                      훅이 공유하는 쉘 라이브러리 (hook-guard.sh)

--- a/README.ko.md
+++ b/README.ko.md
@@ -285,7 +285,9 @@ cd claude-forge && ./install.sh
 
 소요 시간은 재개를 감안해서 계산해요. `--continue`로 며칠 뒤에 다시 연 세션은 처음부터 끝까지 재면 수백 시간이 나오는데, 그건 실제로 일한 시간이 아니죠. 그래서 오래 비어 있던 구간을 기준으로 타임라인을 끊고 마지막 구간만 헤드라인에 씁니다. 재개한 세션이면 뒤에 `(재개 3회, 누적 9h 40m)`을 덧붙여요.
 
-끄고 싶으면 `FORGE_SESSION_TIME_REPORT=0`, 구간을 나누는 공백 기준은 `FORGE_SESSION_GAP_MIN`(기본 60분), 표시 언어는 `FORGE_SESSION_REPORT_LANG`(`en`/`ko`, 기본은 `LANG` 자동 감지)으로 조정합니다. 매 세션 기록이 `~/.claude/work-log/session-times.jsonl`에도 쌓이고, 아직 안 보여준 리포트는 `~/.claude/work-log/.session-time-pending.json`에서 다음 세션을 기다려요.
+끄고 싶으면 `FORGE_SESSION_TIME_REPORT=0`, 구간을 나누는 공백 기준은 `FORGE_SESSION_GAP_MIN`(기본 60분), 훑는 양은 `FORGE_SESSION_MAX_MB`(기본 128, 최대 512), 훑는 시간은 `FORGE_SESSION_MAX_SEC`(기본 4초), 표시 언어는 `FORGE_SESSION_REPORT_LANG`(`en`/`ko`, 기본은 `LANG` 자동 감지)으로 조정합니다.
+
+매 세션 기록은 `~/.claude/work-log/session-times.jsonl`에 쌓이고(1MB에서 오래된 쪽부터 잘라냄), 아직 안 보여준 리포트는 `~/.claude/work-log/.session-time-pending.jsonl`에 줄 단위로 쌓여서 다음 세션을 기다려요. 세션을 여러 개 닫아두고 하나만 새로 열어도 빠지는 것 없이 다 세어줍니다. 로그 파일은 만들 때부터 `0600`이고, 그 경로에 심볼릭 링크가 놓여 있으면 따라가지 않고 그냥 건너뜁니다.
 
 **Opt-in 예제 (직접 활성화 가능)**:
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,9 @@
   <a href="README.ko.md">한국어</a>
 </p>
 
-> **v4.1.0 (August 2026, latest)** — Adds **harness-diet** (33rd skill): measure your always-loaded context (CLAUDE.md + rules) and shrink it back under budget without losing governance.
+> **v4.2.0 (September 2026, latest)** — Adds **session-time-report** (22nd hook): measures each session as it closes and tells you at your next start what time it ended, how long it actually ran, and how much you got through. Resume-aware, so a session you picked back up days later reports that sitting rather than a bogus 400-hour total.
+>
+> **v4.1.0 (August 2026)** — Adds **harness-diet** (33rd skill): measure your always-loaded context (CLAUDE.md + rules) and shrink it back under budget without losing governance.
 >
 > **v4.0.0 (August 2026)** — Introduces the **adversarial verification loop**: every behavioral change is checked by a second, independent agent that did not write the code and never sees the first agent's reasoning — maker≠checker until it issues `APPROVE`. Building v4.0 itself, the loop caught three real defects in the maintainer's own PRs (#58, #61); worked example: [`docs/VERIFICATION-LOOP.md`](docs/VERIFICATION-LOOP.md). Also ships a reliability pack (API-error auto-resume, session relay across `/compact`, doom-loop guard — [`docs/RELIABILITY.md`](docs/RELIABILITY.md)), a debugging escalation chain, task-grade routing, and Korean prose quality guardrails. Details: [What's New in v4.0](#-whats-new-in-v40) · [MIGRATION.md](MIGRATION.md).
 >
@@ -55,7 +57,7 @@ Claude Forge is the **equipment pack** for that assistant. One install gives it:
 - 16 specialist "colleagues" (agents) it can delegate to — planner, security reviewer, TDD guide, adversarial reviewer, and more
 - 35 one-word shortcuts (commands like `/plan`, `/tdd`, `/code-review`) that trigger full workflows
 - 33 saved procedures (skills) it follows automatically
-- 21 safety checks (hooks) that run silently in the background every time it touches your code — including an unattended API-error auto-resume and a doom-loop guard
+- 22 safety checks (hooks) that run silently in the background every time it touches your code — including an unattended API-error auto-resume, a doom-loop guard, and an end-of-session time report
 - 14 rule files that define how it should behave
 - 4 external tool connections (browser automation, live docs search, and more)
 
@@ -119,7 +121,7 @@ cd claude-forge
 | Commands (35 shortcuts)        | ✅ | ✅ |
 | Skills (33 saved procedures)   | ⚠️ partial | ✅ |
 | Agents (16 specialists)        | ❌ | ✅ |
-| Hooks (21 safety checks)       | ❌ | ✅ |
+| Hooks (22 safety checks)       | ❌ | ✅ |
 | Rules (14 behavior guidelines)  | ❌ | ✅ |
 | MCP connections (4 tools)      | ❌ | ✅ |
 
@@ -140,7 +142,7 @@ Here is everything bundled in Claude Forge, explained in plain language:
 | **Agents** (specialist colleagues) | 16 | Each one is an AI focused on a single job — planner, architect, security checker, test guide, database expert, adversarial reviewer, and more. Claude calls the right one automatically. |
 | **Commands** (shortcut buttons) | 35 | Type `/plan` and Claude creates a full implementation plan. Type `/tdd` and it writes tests first, then code. All 35 are pre-built shortcuts for common developer tasks. |
 | **Skills** (saved procedures) | 33 | Step-by-step playbooks Claude follows automatically — like a recipe it has memorized. `loop-forge` turns any repetitive task into a reusable slash command in seconds; `review-loop` runs the maker≠checker verification cycle. |
-| **Hooks** (silent safety checks) | 21 built-in + 9 opt-in examples | These run before and after every action Claude takes. They block leaked passwords, dangerous database commands, and unsafe remote scripts — and, new in v4.0, they auto-resume a session after a retryable API error and nudge you when you're stuck editing the same file. Covers 21 lifecycle events. |
+| **Hooks** (silent safety checks) | 22 built-in + 9 opt-in examples | These run before and after every action Claude takes. They block leaked passwords, dangerous database commands, and unsafe remote scripts — and, new in v4.0, they auto-resume a session after a retryable API error and nudge you when you're stuck editing the same file. Covers 21 lifecycle events. |
 | **Rules** (behavior guidelines) | 14 | Written instructions Claude reads at the start of every session — coding style, security principles, git workflow conventions, when the verification loop is mandatory, and more. |
 | **MCP connections** (external tools) | 4 | Browser automation (Playwright), live library docs (context7), web page reader (jina-reader), and Chrome DevTools for performance audits. |
 
@@ -308,7 +310,7 @@ Here is everything bundled in Claude Forge, explained in plain language:
 </details>
 
 <details>
-<summary><strong>Full list: 21 Hooks (safety checks)</strong></summary>
+<summary><strong>Full list: 22 Hooks (safety checks)</strong></summary>
 
 #### Security Hooks — block dangerous actions automatically
 
@@ -342,7 +344,9 @@ Here is everything bundled in Claude Forge, explained in plain language:
 |:-----|:------------|:-------------|
 | `code-quality-reminder.sh` | After file edits | Reminds about immutability, small files, error handling |
 | `context-sync-suggest.sh` | Session start | Suggests syncing docs at session start |
+| `forge-update-check.sh` | Session start | Tells you when a newer claude-forge release is available |
 | `session-wrap-suggest.sh` | Before session end | Suggests session wrap-up before ending |
+| `session-time-report.sh` | Session ends, replayed at your next session start | Reports end time, how long it ran, and prompt/tool/file-change counts — see [End-of-session report](#end-of-session-report) |
 | `work-tracker-prompt.sh` | When you submit a prompt | Tracks work for analytics |
 | `work-tracker-tool.sh` | After tool use | Tracks tool usage for analytics |
 | `work-tracker-stop.sh` | On stop | Finalizes work tracking data |
@@ -352,6 +356,31 @@ Here is everything bundled in Claude Forge, explained in plain language:
 An opt-in **pre-commit secret guard** (`scripts/install-precommit.sh`) also ships as of v4.0
 — it protects git commits in any repo you point it at, separately from the hooks above.
 See [`docs/RELIABILITY.md`](docs/RELIABILITY.md).
+
+#### End-of-session report
+
+`session-time-report.sh` measures a session as it closes and hands you the summary the next time you open one:
+
+```
+[Claude Forge] Previous session ended 21:34 KST
+2h 17m elapsed · 18 prompts · 143 tool calls · 9 files changed
+Log: ~/.claude/work-log/session-time-<session_id>.json
+```
+
+**Why it is wired to two events.** `SessionEnd` is where the numbers are, but it cannot talk to you: Claude Code forwards a SessionEnd hook's output only when that hook *failed*, so a successful report is thrown away. `SessionStart` is a channel that does reach you. So the same script records on the way out and reports on the way in, exactly once per session.
+
+It reads only the session transcript, so there is no network call and no extra dependency beyond `python3`.
+
+**Elapsed time is resume-aware.** A transcript you reopened days later spans hundreds of hours of wall clock, which is not what you worked. The hook splits the timeline wherever there is a long idle gap and reports the *latest stretch*; if the session was resumed, it appends `(resumed 3x, 9h 40m total)`.
+
+| Environment variable | Default | Effect |
+|:---------------------|:--------|:-------|
+| `FORGE_SESSION_TIME_REPORT` | `1` | Set to `0` to turn the hook off |
+| `FORGE_SESSION_GAP_MIN` | `60` | Idle minutes that start a new stretch |
+| `FORGE_SESSION_MAX_MB` | `128` | Transcript bytes to scan; larger files are read from the tail |
+| `FORGE_SESSION_REPORT_LANG` | auto | `en` or `ko`; auto-detects from `LANG` / `LC_ALL` |
+
+Every run also appends to `~/.claude/work-log/session-times.jsonl` (mode `600`), so you can chart your own sessions later. The pending report waits in `~/.claude/work-log/.session-time-pending.json` until the next session drains it.
 
 #### Opt-in Examples (9 extra, v3.0+)
 
@@ -454,7 +483,7 @@ claude-forge/
   ├── cc-chips-custom/           Custom status bar overlay
   ├── commands/                  Slash commands (35 .md, 8 dirs moved to skills/)
   ├── docs/                      Screenshots, diagrams, policy docs (v3.0+ guides, incl. RELIABILITY.md / VERIFICATION-LOOP.md)
-  ├── hooks/                     Event-driven shell scripts (21)
+  ├── hooks/                     Event-driven shell scripts (22)
   │   └── examples/              Opt-in .example samples for 21 lifecycle events (9)
   ├── knowledge/                 Knowledge base entries
   ├── libs/                      Shared shell libraries hooks source (hook-guard.sh)
@@ -467,8 +496,8 @@ claude-forge/
   ├── install.ps1                Windows installer (--upgrade supported)
   ├── mcp-servers.json           MCP server defaults (4 minimal)
   ├── mcp-servers.optional.json  Optional MCP servers (memory/exa/github/fetch/time/...)
-  ├── .claude-plugin/plugin.json Plugin manifest (4.1.0)
-  ├── .claude-plugin/marketplace.json  Marketplace entry (4.1.0)
+  ├── .claude-plugin/plugin.json Plugin manifest (4.2.0)
+  ├── .claude-plugin/marketplace.json  Marketplace entry (4.2.0)
   ├── settings.json              Claude Code settings (2026 fields)
   ├── MIGRATION.md               v2.1 → v4.0 migration guide (EN)
   ├── MIGRATION.ko.md            v2.1 → v4.0 migration guide (KO)
@@ -578,7 +607,7 @@ cp setup/settings.local.template.json ~/.claude/settings.local.json
 | Specialist agents | 16 ready | Manual setup | Varies |
 | Slash commands | 35 ready | None | Per-plugin |
 | Skill workflows | 33 ready | None | Per-plugin |
-| Safety hooks | 21 + 9 examples | None by default | Per-plugin |
+| Safety hooks | 22 + 9 examples | None by default | Per-plugin |
 | External tool connections | 4 default (8+ optional) | None | Per-plugin |
 | Setup time | ~5 minutes | Hours | Per-plugin install |
 | Updates | `git pull` | Manual per-file | Per-plugin update |
@@ -607,7 +636,7 @@ Claude Code is Anthropic's official AI coding assistant that runs in your termin
 <details>
 <summary><strong>How is Claude Forge different from other Claude Code plugins?</strong></summary>
 
-Most Claude Code plugins solve one problem at a time. Claude Forge is a complete development environment — 16 agents, 35 commands, 33 skills, 21 hooks, and 14 rules that work together as a cohesive system. Instead of assembling individual plugins, you get a pre-wired pipeline: `/plan` feeds into `/tdd`, which feeds into `/code-review`, which feeds into `/handoff-verify`, which feeds into `/commit-push-pr` — and, new in v4.0, an adversarial verification loop that a fresh reviewer must `APPROVE` before any behavioral change is considered done. The 6-layer security hook system also runs automatically without extra configuration.
+Most Claude Code plugins solve one problem at a time. Claude Forge is a complete development environment — 16 agents, 35 commands, 33 skills, 22 hooks, and 14 rules that work together as a cohesive system. Instead of assembling individual plugins, you get a pre-wired pipeline: `/plan` feeds into `/tdd`, which feeds into `/code-review`, which feeds into `/handoff-verify`, which feeds into `/commit-push-pr` — and, new in v4.0, an adversarial verification loop that a fresh reviewer must `APPROVE` before any behavioral change is considered done. The 6-layer security hook system also runs automatically without extra configuration.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -377,10 +377,11 @@ It reads only the session transcript, so there is no network call and no extra d
 |:---------------------|:--------|:-------|
 | `FORGE_SESSION_TIME_REPORT` | `1` | Set to `0` to turn the hook off |
 | `FORGE_SESSION_GAP_MIN` | `60` | Idle minutes that start a new stretch |
-| `FORGE_SESSION_MAX_MB` | `128` | Transcript bytes to scan; larger files are read from the tail |
+| `FORGE_SESSION_MAX_MB` | `128` | Transcript megabytes to scan, up to 512; larger files are read from the tail |
+| `FORGE_SESSION_MAX_SEC` | `4` | Wall-clock budget for the scan. Past it the report is dropped rather than reported half-read |
 | `FORGE_SESSION_REPORT_LANG` | auto | `en` or `ko`; auto-detects from `LANG` / `LC_ALL` |
 
-Every run also appends to `~/.claude/work-log/session-times.jsonl` (mode `600`), so you can chart your own sessions later. The pending report waits in `~/.claude/work-log/.session-time-pending.json` until the next session drains it.
+Every run also appends to `~/.claude/work-log/session-times.jsonl` (mode `600`, rotated at 1 MB), so you can chart your own sessions later. Reports queue in `~/.claude/work-log/.session-time-pending.jsonl` until a session drains them, so ending several sessions before starting a new one does not lose any of them. Log files are created `0600` and the hook refuses to follow a symlink planted at one of those paths.
 
 #### Opt-in Examples (9 extra, v3.0+)
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -34,6 +34,10 @@
   <a href="#-常见问题">常见问题</a>
 </p>
 
+> **v4.2.0（2026 年 9 月，最新）** — 新增 **session-time-report**（第 22 个钩子）：会话结束时记下几点结束、实际用了多久、期间提交了多少提示词、调用了多少次工具、改动了几个文件，并在你下次开启会话时告诉你。计时能识别续接：隔了几天用 `--continue` 重新打开的会话，只统计这一次坐下来的时长，不会给出几百小时的假数字。记录同时写入 `~/.claude/work-log/`。
+>
+> **v4.1.0（2026 年 8 月）** — 新增 **harness-diet**（第 33 个技能）：实测常驻加载的上下文（CLAUDE.md + rules），在不丢失治理规则的前提下把它压回预算之内。
+>
 > **v4.0.0（2026 年 8 月）** — 核心是**对抗式验证循环（adversarial verification loop）**：每一次行为变更都由一个从未写过这段代码、也不了解作者思路的独立审查员（`adversarial-reviewer`）复核——作者与审查者必须是两个不同的角色（maker≠checker），直到审查员给出 `APPROVE` 才算完成。这不是纸上谈兵：在开发 v4.0 本身的过程中，该循环就在维护者自己的 PR（#58、#61）里发现了三个真实缺陷——一个能通过自身回归测试的 CI 校验、修复该校验时在同一处留下的同类漏洞、以及一个悄悄锁定在一年前旧版本上的依赖上限。完整验证记录见 [`docs/VERIFICATION-LOOP.md`](docs/VERIFICATION-LOOP.md)。此外还新增了**可靠性套件**（API 报错后的无人值守自动续接、`/compact` 后仍可继续的会话交接、死循环与编辑后即时校验钩子、可选的 pre-commit 密钥防泄漏、以及它们共用的 `libs/hook-guard.sh`，接线指南见 [`docs/RELIABILITY.md`](docs/RELIABILITY.md)）、**调试升级链**（`systematic-debugger` → `rca-debugger` → `escalation-fixer`）、**任务难度自动分级**（`/workflow-classify` 按 S/M/L/XL 给任务分级，并据此调整文档深度与验证力度），以及**韩语行文质量护栏**（从生成之初就避免翻译腔和 AI 套话，详见韩文版 README）。智能体 16 个、命令 35 个、技能 32 个、钩子 21 个、规则 14 份。详见 [MIGRATION.md](MIGRATION.md)。
 >
 > **v3.1.1 热修复（2026 年 8 月）** — 修复插件安装后完全无法加载的问题（`Hook load failed: expected record, received undefined`）。如果执行 `/plugin install claude-forge` 后显示 `✘ failed to load`、技能/智能体/命令一个都没出现，请升级到 3.1.1。同时修复 Windows `install.ps1` 未复制 statusLine 与 `scripts/` 的问题。相关：[#52](https://github.com/sangrokjung/claude-forge/issues/52)、[#57](https://github.com/sangrokjung/claude-forge/issues/57)、[#50](https://github.com/sangrokjung/claude-forge/issues/50)。
@@ -59,7 +63,7 @@ curl -fsSL https://raw.githubusercontent.com/sangrokjung/claude-forge/main/insta
 - **16 位领域专家**（智能体(专属 AI 助理)）：可以把任务分配给它们——规划师、安全审查员、测试向导、对抗式审查员……
 - **35 个一键快捷指令**（命令(触发完整工作流的斜杠指令)）：输入 `/plan`、`/tdd`、`/code-review`，立即启动完整流程
 - **32 套预置操作流程**（技能(Claude 自动跟随执行的步骤手册)）：它会自动按这些步骤走
-- **21 道安全守卫**（钩子(每次操作前后自动运行的安全检查程序)）：静默拦截危险动作，包括 v4.0 新增的 API 报错自动续接和死循环提醒
+- **22 道安全守卫**（钩子(每次操作前后自动运行的安全检查程序)）：静默拦截危险动作，包括 v4.0 新增的 API 报错自动续接和死循环提醒，以及会话结束时的用时小结
 - **14 份行为准则**（规则文件(每次启动自动加载的 AI 行为规范)）：定义它该如何做事
 - **4 个外部工具接入**（MCP 服务器(模型上下文协议，外部工具扩展接口)）：浏览器自动化、实时文档检索等
 
@@ -123,7 +127,7 @@ cd claude-forge
 | 命令（35 个快捷指令）      | ✅ | ✅ |
 | 技能（32 套操作流程）       | ⚠️ 部分支持 | ✅ |
 | 智能体（16 位专家）         | ❌ | ✅ |
-| 钩子（21 道安全守卫）       | ❌ | ✅ |
+| 钩子（22 道安全守卫）       | ❌ | ✅ |
 | 规则文件（14 份行为准则）    | ❌ | ✅ |
 | MCP 连接（4 个外部工具）    | ❌ | ✅ |
 
@@ -144,7 +148,7 @@ Claude Forge 包含的全部内容，用大白话说明：
 | **智能体**（专属 AI 助理） | 16 个 | 每个专注一个领域——规划师、架构师、安全检查员、测试向导、数据库专家、对抗式审查员等。Claude 会自动调用合适的那位。 |
 | **命令**（一键快捷指令） | 35 个 | 输入 `/plan`，Claude 就生成完整实施方案；输入 `/tdd`，先写测试再写代码。35 个预置快捷键，覆盖常见开发任务。 |
 | **技能**（操作步骤手册） | 32 套 | Claude 已经「背熟」的分步操作流程，会自动执行。`loop-forge` 能把任何重复任务在几秒内封装成可复用的斜杠命令，`review-loop` 负责跑对抗式验证循环。 |
-| **钩子**（自动安全检查程序） | 21 个内置 + 9 个可选示例 | 在 Claude 每次操作前后运行，自动拦截泄漏的密码、危险的数据库命令和不安全的远程脚本，v4.0 起还能在 API 报错后自动续接会话、在你反复卡在同一个文件时提醒你。覆盖 21 个生命周期事件。 |
+| **钩子**（自动安全检查程序） | 22 个内置 + 9 个可选示例 | 在 Claude 每次操作前后运行，自动拦截泄漏的密码、危险的数据库命令和不安全的远程脚本，v4.0 起还能在 API 报错后自动续接会话、在你反复卡在同一个文件时提醒你。覆盖 21 个生命周期事件。 |
 | **规则文件**（行为准则） | 14 份 | 每次会话开始时 Claude 自动读取的书面规范——编码风格、安全原则、Git 工作流约定、对抗式验证循环何时强制启动等。 |
 | **MCP 服务器**（外部工具接入） | 4 个 | 浏览器自动化（Playwright）、实时库文档（context7）、网页内容读取（jina-reader）、Chrome 性能审计（chrome-devtools）。 |
 
@@ -211,10 +215,16 @@ Claude 会根据任务性质自动调用合适的智能体，你不需要手动�
 | `post-compact-restore.sh` | `/compact` 之后（`SessionStart`，matcher `compact`） | 把该指针恢复进新会话的上下文，仅恢复一次 |
 | `emdash-slop-guard.sh` | 编辑韩语占比高的 `.md` 文件后 | 标记破折号插入语这类韩语行文中的 AI 痕迹，详见 [`rules/korean-writing-quality.md`](rules/korean-writing-quality.md) |
 
+**v4.2 新增：会话观测钩子（1 个）**
+
+| 钩子 | 运行时机 | 做什么 |
+|:----|:--------|:------|
+| `session-time-report.sh` | 会话结束时记账（`SessionEnd`），下次开启会话时回放（`SessionStart`） | 汇总结束时间、本次时长和提示词/工具/改动文件数，并写入 `~/.claude/work-log/`。续接过的会话只统计最近一段。之所以挂在两个事件上：Claude Code 只有在 SessionEnd 钩子**失败**时才转发它的输出，正常完成的报告会被丢弃，所以由 SessionStart 负责说给你听 |
+
 完整接线指南见 [`docs/RELIABILITY.md`](docs/RELIABILITY.md)。另外 v4.0 还新增了一个可选的 pre-commit
 密钥防泄漏脚本（`scripts/install-precommit.sh`），它和上面的钩子不同，是你自己安装到指定 git 仓库、保护提交安全的独立工具。
 
-额外 9 个可选示例钩子（覆盖 SessionEnd、PreCompact、SubagentStart/Stop 等更多事件）存放在 [`hooks/examples/`](hooks/examples/) 目录。完整 21 事件目录：[`hooks/README.md`](hooks/README.md)。启用方法：把 `*.example` 文件改名为 `*.sh`，然后在 `settings.json` 中注册。
+额外 9 个可选示例钩子（覆盖 PreCompact、SubagentStart/Stop、WorktreeCreate/Remove 等更多事件）存放在 [`hooks/examples/`](hooks/examples/) 目录。完整 21 事件目录：[`hooks/README.md`](hooks/README.md)。启用方法：把 `*.example` 文件改名为 `*.sh`，然后在 `settings.json` 中注册。
 
 ---
 
@@ -582,7 +592,7 @@ claude-forge/
   ├── cc-chips-custom/           自定义状态栏覆盖层
   ├── commands/                  斜杠命令（35 个 .md，8 个目录已迁移至 skills/）
   ├── docs/                      截图、图表、策略文档（含 RELIABILITY.md、VERIFICATION-LOOP.md）
-  ├── hooks/                     事件驱动 shell 脚本（21 个）
+  ├── hooks/                     事件驱动 shell 脚本（22 个）
   │   └── examples/              21 个生命周期事件的可选示例（9 个）
   ├── knowledge/                 知识库条目
   ├── libs/                      钩子共用的 shell 库（hook-guard.sh）
@@ -595,8 +605,8 @@ claude-forge/
   ├── install.ps1                Windows 安装程序（支持 --upgrade）
   ├── mcp-servers.json           MCP 服务器默认配置（4 个最小集）
   ├── mcp-servers.optional.json  可选 MCP 服务器（memory/exa/github/fetch/time/...）
-  ├── .claude-plugin/plugin.json 插件清单（4.0.0）
-  ├── .claude-plugin/marketplace.json  市场条目（4.0.0）
+  ├── .claude-plugin/plugin.json 插件清单（4.2.0）
+  ├── .claude-plugin/marketplace.json  市场条目（4.2.0）
   ├── settings.json              Claude Code 设置（2026 字段）
   ├── MIGRATION.md               v2.1 → v4.0 迁移指南（英文）
   ├── MIGRATION.ko.md            v2.1 → v4.0 迁移指南（韩文）

--- a/docs/MARKETPLACE-SUBMISSION.md
+++ b/docs/MARKETPLACE-SUBMISSION.md
@@ -18,7 +18,7 @@
 | Public repository | <https://github.com/sangrokjung/claude-forge> |
 | Homepage | <https://github.com/sangrokjung/claude-forge> |
 | License | MIT |
-| Current version | `4.1.0` |
+| Current version | `4.2.0` |
 | Manifest file | `.claude-plugin/plugin.json` |
 | Marketplace manifest | `.claude-plugin/marketplace.json` |
 | Category | development |
@@ -27,7 +27,7 @@
 ## 2. One-paragraph pitch
 
 claude-forge is an "oh-my-zsh for Claude Code" — a cohesive distribution of 16 specialized
-agents, 35 slash commands, 33 skills, 21 automation hooks (plus 9 opt-in examples covering
+agents, 35 slash commands, 33 skills, 22 automation hooks (plus 9 opt-in examples covering
 21 lifecycle events), 14 rule files, and a minimal 4-server MCP set (playwright, context7,
 jina-reader, chrome-devtools pinned at `@0.23.0`). v4.0 adds an adversarial verification
 loop (maker≠checker, dispatched until an independent reviewer issues APPROVE), unattended
@@ -47,7 +47,7 @@ preview.
 - **35 commands** (`/auto-ship`, `/plan`, `/review`, `/e2e`, `/worktree-start`,
   `/workflow-classify`, ...)
 - **33 skills** under `skills/<name>/SKILL.md`
-- **21 hooks + 9 opt-in examples** covering 21 of the 27 official hook events
+- **22 hooks + 9 opt-in examples** covering 21 of the 27 official hook events
 - **14 rules** (Golden Principles, interaction, coding-style, verification, security,
   testing, git-workflow, date-calculation, agents-v2, adversarial-review,
   api-error-recovery, korean-writing-quality, task-grade-routing, unknowns-lens)

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -29,9 +29,11 @@ Claude Code exposes **27 hookable events** across 7 categories (official catalog
 |----------|-------|---------|------------|---------|
 | Session | `SessionStart` | New session boots / `--continue` resume | Inject context, warm caches, print banners | `context-sync-suggest.sh` |
 | Session | `SessionStart` | Session resumes right after `/compact` (matcher: `compact`) | Restore the next-task pointer left before compaction (relay skill) | `post-compact-restore.sh` |
-| Session | `SessionEnd` | Clean session shutdown | Persist summary, sync TODAY.md | `work-tracker-stop.sh` |
+| Session | `SessionStart` | New session boots | Replay the previous session's time report, once | `session-time-report.sh` (`FORGE_SESSION_MODE=report`) |
+| Session | `SessionEnd` | Clean session shutdown | Measure end time, elapsed, prompt/tool/file counts and file the report | `session-time-report.sh` |
 | Turn | `UserPromptSubmit` | User sends a prompt | Track activity, pre-flight checks | `work-tracker-prompt.sh` |
 | Turn | `Stop` | Assistant finishes a clean turn | Nudge session-wrap, commit suggest | `session-wrap-suggest.sh` |
+| Turn | `Stop` | Assistant finishes a clean turn | Persist the work-tracking buffer, trigger sync | `work-tracker-stop.sh` |
 | Turn | `StopFailure` | Session ends abnormally (crash, rate-limit) | Dump crash report, set recovery flag | `examples/stop-failure.sh.example` |
 | Turn | `StopFailure` | Session dies on a retryable API error (529 / 5xx / stalled stream) | Schedule an unattended resume, under fork-bomb caps — see [`rules/api-error-recovery.md`](../rules/api-error-recovery.md) | `api-error-auto-resume.sh` |
 | Tool | `PreToolUse` | Before a tool runs | Guard destructive commands, rate-limit MCP | `remote-command-guard.sh` |

--- a/hooks/session-time-report.sh
+++ b/hooks/session-time-report.sh
@@ -396,11 +396,27 @@ def read_claim(path):
     return records
 
 
-def stale_claims(path):
-    """Claims left behind by a run that died mid-drain.
+def owner_gone(name, prefix):
+    """True when the process that made this claim is no longer running.
 
-    Only old ones: a drain running right now holds a fresh claim, and stealing it
-    would render the same report twice."""
+    Age alone is not enough. mtime is settable by the same user, and a drain that
+    stalls past the cutoff still owns its claim; taking it would show the same
+    report twice. A recycled pid reads as alive, which only delays recovery to a
+    later start."""
+    suffix = name[len(prefix):]
+    if not suffix.isdigit():
+        return True          # not ours to reason about, fall back to age
+    try:
+        os.kill(int(suffix), 0)
+    except ProcessLookupError:
+        return True
+    except (OSError, ValueError):
+        return False         # alive, or owned by someone else
+    return False
+
+
+def stale_claims(path):
+    """Claims left behind by a run that died mid-drain."""
     directory, prefix = os.path.dirname(path), os.path.basename(path) + ".claimed-"
     cutoff = time.time() - STALE_CLAIM_SEC
     found = []
@@ -409,7 +425,7 @@ def stale_claims(path):
     except OSError:
         return found
     for name in names:
-        if not name.startswith(prefix):
+        if not name.startswith(prefix) or not owner_gone(name, prefix):
             continue
         candidate = os.path.join(directory, name)
         try:

--- a/hooks/session-time-report.sh
+++ b/hooks/session-time-report.sh
@@ -22,10 +22,11 @@
 #               report mode  - stdout, the standard SessionStart channel
 # Log:          ~/.claude/work-log/session-time-<session_id>.json   (snapshot, 600)
 #               ~/.claude/work-log/session-times.jsonl              (history, 600)
-# State:        ~/.claude/work-log/.session-time-pending.json       (drained once, 600)
+# State:        ~/.claude/work-log/.session-time-pending.jsonl      (queue, drained once, 600)
 # Environment:  FORGE_SESSION_TIME_REPORT=0  kill switch (both modes)
 #               FORGE_SESSION_GAP_MIN        idle minutes that start a new stretch (default 60)
-#               FORGE_SESSION_MAX_MB         transcript scan budget in MB (default 128)
+#               FORGE_SESSION_MAX_MB         transcript scan budget in MB (default 128, max 512)
+#               FORGE_SESSION_MAX_SEC        wall-clock budget for the scan (default 4, max 30)
 #               FORGE_SESSION_REPORT_LANG    en | ko (default: auto-detect from LANG/LC_ALL)
 #
 # Elapsed time is resume-aware (CRITICAL). Do NOT report last-minus-first over the
@@ -34,7 +35,12 @@
 # exceeds FORGE_SESSION_GAP_MIN, and the headline always describes the LATEST
 # stretch. Cumulative totals are appended only when they are trustworthy.
 #
-# Reads the transcript only. No network call, no dependency beyond python3.
+# Reads the transcript only. No network call, no dependency beyond python3. Log
+# files are created 0600 with O_NOFOLLOW, so a symlink planted at one of the log
+# paths is refused rather than followed, and nothing is ever written outside
+# ~/.claude/work-log/. If either budget above runs out the report is dropped
+# entirely: a partial tail scan would omit the newest events, which are the ones
+# the headline is about.
 # exit 0 required (never disturb session start or teardown)
 
 [ "${FORGE_SESSION_TIME_REPORT:-1}" = "0" ] && exit 0
@@ -59,7 +65,8 @@ import json
 import os
 import re
 import sys
-from datetime import datetime
+import time
+from datetime import datetime, timezone
 
 EDIT_TOOLS = {"Edit", "Write", "NotebookEdit", "MultiEdit"}
 
@@ -73,12 +80,15 @@ def env_int(name, default, low, high):
 
 
 def parse_ts(raw):
+    """Always returns an aware datetime. A transcript that mixes naive and aware
+    stamps would otherwise make the sort raise, and the report would vanish."""
     if not isinstance(raw, str) or not raw:
         return None
     try:
-        return datetime.fromisoformat(raw.replace("Z", "+00:00"))
+        stamp = datetime.fromisoformat(raw.replace("Z", "+00:00"))
     except ValueError:
         return None
+    return stamp if stamp.tzinfo else stamp.replace(tzinfo=timezone.utc)
 
 
 def open_budgeted(path, max_bytes):
@@ -93,15 +103,36 @@ def open_budgeted(path, max_bytes):
     return handle, True
 
 
-def collect(path, max_bytes):
-    """Turn transcript lines into (timestamp, prompt, tool_calls, files, sidechain)."""
+def open_private(path, append):
+    """Create at 0600 in one step and refuse to follow a symlink.
+
+    open() + chmod() leaves the file at the umask default while it already holds
+    content, and both calls follow symlinks, so a link planted at the target path
+    gets its contents replaced and its mode narrowed. O_NOFOLLOW plus a creation
+    mode closes both."""
+    flags = os.O_WRONLY | os.O_CREAT | os.O_NOFOLLOW
+    flags |= os.O_APPEND if append else os.O_TRUNC
+    return os.fdopen(os.open(path, flags, 0o600), "a" if append else "w",
+                     encoding="utf-8")
+
+
+def collect(path, max_bytes, deadline):
+    """Turn transcript lines into (timestamp, prompt, tool_calls, files, sidechain).
+
+    Abandons the whole report if the deadline passes. Stopping early would drop
+    the newest events, which are exactly the ones the headline describes, so a
+    partial scan is worth less than no report at all."""
     try:
         handle, truncated = open_budgeted(path, max_bytes)
     except OSError:
         return None
     events = []
+    scanned = 0
     with handle:
         for line in handle:
+            scanned += 1
+            if scanned % 2000 == 0 and time.monotonic() > deadline:
+                return None
             line = line.strip()
             if not line:
                 continue
@@ -198,63 +229,109 @@ def pick_lang():
     return "ko" if locale.lower().startswith("ko") else "en"
 
 
-def write_log(record, session_id):
-    log_dir = os.path.expanduser("~/.claude/work-log")
+def log_dir():
+    """~/.claude/work-log, created private. A directory that already exists is
+    left as the user set it: this path is shared with the work-tracker hooks."""
+    path = os.path.expanduser("~/.claude/work-log")
     try:
-        os.makedirs(log_dir, exist_ok=True)
+        os.makedirs(path, mode=0o700, exist_ok=True)
     except OSError:
         return None
+    return path
+
+
+def write_line(path, line, append):
+    # OSError here covers the ordinary cases (read-only mount, full disk) and the
+    # interesting one: ELOOP, meaning something planted a symlink at our path. Both
+    # end the same way. This hook may not stand between the user and their session
+    # over a log line, so it gives up quietly.
+    try:
+        with open_private(path, append) as handle:
+            handle.write(line + "\n")
+        return True
+    except OSError:
+        return False
+
+
+HISTORY_MAX_BYTES = 1024 * 1024
+
+
+def rotate(path):
+    """Keep the newest half once the history crosses its ceiling."""
+    try:
+        if os.path.getsize(path) <= HISTORY_MAX_BYTES:
+            return
+        with open(path, encoding="utf-8", errors="replace") as handle:
+            handle.seek(os.path.getsize(path) - HISTORY_MAX_BYTES // 2)
+            handle.readline()
+            kept = handle.read()
+        with open_private(path, append=False) as handle:
+            handle.write(kept)
+    except OSError:
+        pass
+
+
+def write_log(record, session_id):
+    directory = log_dir()
+    if not directory:
+        return None
     line = json.dumps(record, ensure_ascii=False)
-    snapshot = os.path.join(log_dir, "session-time-%s.json" % session_id)
-    history = os.path.join(log_dir, "session-times.jsonl")
-    written = None
-    try:
-        with open(snapshot, "w", encoding="utf-8") as handle:
-            handle.write(line + "\n")
-        os.chmod(snapshot, 0o600)
-        written = snapshot
-    except OSError:
-        pass
-    try:
-        with open(history, "a", encoding="utf-8") as handle:
-            handle.write(line + "\n")
-        os.chmod(history, 0o600)
-    except OSError:
-        pass
-    return written
+    snapshot = os.path.join(directory, "session-time-%s.json" % session_id)
+    history = os.path.join(directory, "session-times.jsonl")
+    if write_line(history, line, append=True):
+        rotate(history)
+    return snapshot if write_line(snapshot, line, append=False) else None
 
 
 def pending_path():
-    return os.path.expanduser("~/.claude/work-log/.session-time-pending.json")
+    return os.path.expanduser("~/.claude/work-log/.session-time-pending.jsonl")
 
 
 def stash(record):
-    """Leave the report where the next SessionStart will find it."""
-    path = pending_path()
-    try:
-        with open(path, "w", encoding="utf-8") as handle:
-            handle.write(json.dumps(record, ensure_ascii=False) + "\n")
-        os.chmod(path, 0o600)
-    except OSError:
-        pass
+    """Queue the report for the next SessionStart.
+
+    Appended, not overwritten: several sessions can end before any new one starts,
+    and a plain write would drop every announcement but the last."""
+    if log_dir():
+        write_line(pending_path(), json.dumps(record, ensure_ascii=False), append=True)
 
 
 def drain():
-    """Take the pending report and clear it, so it is shown exactly once."""
+    """Claim the queue and return everything in it, oldest first.
+
+    The rename is the claim: it is atomic, so two sessions starting at once cannot
+    both read the same entries, and nothing is rendered from a file we failed to
+    take. Reading first and deleting after would replay the report on a delete
+    failure, and lose entries appended in between."""
     path = pending_path()
+    claimed = "%s.claimed-%d" % (path, os.getpid())
     try:
-        with open(path, encoding="utf-8") as handle:
-            record = json.load(handle)
-    except (OSError, ValueError):
-        return None
+        os.rename(path, claimed)
+    except OSError:
+        return []
+    records = []
     try:
-        os.remove(path)
+        with open(claimed, encoding="utf-8") as handle:
+            for line in handle:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    entry = json.loads(line)
+                except ValueError:
+                    continue
+                if isinstance(entry, dict):
+                    records.append(entry)
     except OSError:
         pass
-    return record if isinstance(record, dict) else None
+    try:
+        os.remove(claimed)
+    except OSError:
+        pass
+    return records
 
 
-def render(record, previous):
+def render(record, previous, also=0):
     lang = pick_lang()
     stamp = record.get("ended_label") or "?"
     span = record.get("stretch_seconds") or 0
@@ -292,6 +369,10 @@ def render(record, previous):
             body += " (resumed %dx, %s total)" % (resumed, human(active))
         tail = "Log: %s"
 
+    if also:
+        body += (" · 그 전 세션 %d건은 로그에" % also) if lang == "ko" else (
+            " · %d earlier %s in the log" % (also, "session" if also == 1 else "sessions"))
+
     lines = [head, body]
     if snapshot:
         home = os.path.expanduser("~")
@@ -312,9 +393,10 @@ def measure(payload):
         return None
 
     gap_seconds = env_int("FORGE_SESSION_GAP_MIN", 60, 1, 1440) * 60
-    max_bytes = env_int("FORGE_SESSION_MAX_MB", 128, 1, 4096) * 1024 * 1024
+    max_bytes = env_int("FORGE_SESSION_MAX_MB", 128, 1, 512) * 1024 * 1024
 
-    scanned = collect(transcript, max_bytes)
+    deadline = time.monotonic() + env_int("FORGE_SESSION_MAX_SEC", 4, 1, 30)
+    scanned = collect(transcript, max_bytes, deadline)
     if not scanned:
         return None
     events, truncated = scanned
@@ -350,8 +432,9 @@ def measure(payload):
 
 try:
     if os.environ.get("FORGE_SESSION_MODE") == "report":
-        stashed = drain()
-        text = render(stashed, previous=True) if stashed else None
+        queued = drain()
+        # Newest first: the session you just left is the one you want to read about.
+        text = render(queued[-1], previous=True, also=len(queued) - 1) if queued else None
     else:
         incoming = json.loads(os.environ.get("FORGE_HOOK_INPUT") or "{}")
         measured = measure(incoming) if isinstance(incoming, dict) else None

--- a/hooks/session-time-report.sh
+++ b/hooks/session-time-report.sh
@@ -142,6 +142,49 @@ def open_plain(path):
     return os.fdopen(fd, "r", encoding="utf-8", errors="replace")
 
 
+READ_CHUNK = 1 << 20
+MAX_LINE_BYTES = 16 << 20
+
+
+def iter_lines(handle, deadline):
+    """Yield lines, giving up the moment the budget runs out.
+
+    Iterating the file object directly would read an arbitrarily long line before
+    control came back, which let a single huge line ignore the deadline entirely.
+    A line past MAX_LINE_BYTES is dropped rather than buffered: no real transcript
+    record is that large, and holding it would trade a time problem for a memory
+    one."""
+    buffered = ""
+    overlong = False
+    while True:
+        if time.monotonic() > deadline:
+            raise TimeoutError("scan budget exhausted")
+        block = handle.read(READ_CHUNK)
+        if not block:
+            break
+        if overlong:
+            head, sep, rest = block.partition("\n")
+            if not sep:
+                continue
+            overlong = False
+            block = rest
+        buffered += block
+        if "\n" not in buffered:
+            if len(buffered) > MAX_LINE_BYTES:
+                buffered = ""
+                overlong = True
+            continue
+        parts = buffered.split("\n")
+        buffered = parts.pop()
+        for part in parts:
+            yield part
+        if len(buffered) > MAX_LINE_BYTES:
+            buffered = ""
+            overlong = True
+    if buffered and not overlong:
+        yield buffered
+
+
 def collect(path, max_bytes, deadline):
     """Turn transcript lines into (timestamp, prompt, tool_calls, files, sidechain).
 
@@ -154,9 +197,11 @@ def collect(path, max_bytes, deadline):
         return None
     events = []
     with handle:
-        for line in handle:
-            if time.monotonic() > deadline:
-                return None
+        try:
+            lines = list(iter_lines(handle, deadline))
+        except TimeoutError:
+            return None
+        for line in lines:
             line = line.strip()
             if not line:
                 continue
@@ -320,6 +365,61 @@ def stash(record):
         write_line(pending_path(), json.dumps(record, ensure_ascii=False), append=True)
 
 
+STALE_CLAIM_SEC = 60
+
+
+def read_claim(path):
+    """Parse one claimed queue file and delete it, whatever the contents were.
+
+    The removal is in a finally because a claimed file that survives a parse
+    failure is a batch of announcements lost for good."""
+    records = []
+    try:
+        with open_plain(path) as handle:
+            for line in handle:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    entry = json.loads(line)
+                except (ValueError, RecursionError):
+                    continue
+                if isinstance(entry, dict):
+                    records.append(entry)
+    except OSError:
+        pass
+    finally:
+        try:
+            os.remove(path)
+        except OSError:
+            pass
+    return records
+
+
+def stale_claims(path):
+    """Claims left behind by a run that died mid-drain.
+
+    Only old ones: a drain running right now holds a fresh claim, and stealing it
+    would render the same report twice."""
+    directory, prefix = os.path.dirname(path), os.path.basename(path) + ".claimed-"
+    cutoff = time.time() - STALE_CLAIM_SEC
+    found = []
+    try:
+        names = os.listdir(directory)
+    except OSError:
+        return found
+    for name in names:
+        if not name.startswith(prefix):
+            continue
+        candidate = os.path.join(directory, name)
+        try:
+            if os.path.getmtime(candidate) < cutoff:
+                found.append(candidate)
+        except OSError:
+            continue
+    return sorted(found)
+
+
 def drain():
     """Claim the queue and return everything in it, oldest first.
 
@@ -328,30 +428,15 @@ def drain():
     take. Reading first and deleting after would replay the report on a delete
     failure, and lose entries appended in between."""
     path = pending_path()
+    records = []
+    for orphan in stale_claims(path):
+        records.extend(read_claim(orphan))
     claimed = "%s.claimed-%d" % (path, os.getpid())
     try:
         os.rename(path, claimed)
     except OSError:
-        return []
-    records = []
-    try:
-        with open_plain(claimed) as handle:
-            for line in handle:
-                line = line.strip()
-                if not line:
-                    continue
-                try:
-                    entry = json.loads(line)
-                except ValueError:
-                    continue
-                if isinstance(entry, dict):
-                    records.append(entry)
-    except OSError:
-        pass
-    try:
-        os.remove(claimed)
-    except OSError:
-        pass
+        return records
+    records.extend(read_claim(claimed))
     return records
 
 

--- a/hooks/session-time-report.sh
+++ b/hooks/session-time-report.sh
@@ -26,7 +26,8 @@
 # Environment:  FORGE_SESSION_TIME_REPORT=0  kill switch (both modes)
 #               FORGE_SESSION_GAP_MIN        idle minutes that start a new stretch (default 60)
 #               FORGE_SESSION_MAX_MB         transcript scan budget in MB (default 128, max 512)
-#               FORGE_SESSION_MAX_SEC        wall-clock budget for the scan (default 4, max 30)
+#               FORGE_SESSION_MAX_SEC        wall-clock budget for the scan (default 4, max 30;
+#                                            0 skips the scan and reports nothing)
 #               FORGE_SESSION_REPORT_LANG    en | ko (default: auto-detect from LANG/LC_ALL)
 #
 # Elapsed time is resume-aware (CRITICAL). Do NOT report last-minus-first over the
@@ -35,10 +36,10 @@
 # exceeds FORGE_SESSION_GAP_MIN, and the headline always describes the LATEST
 # stretch. Cumulative totals are appended only when they are trustworthy.
 #
-# Reads the transcript only. No network call, no dependency beyond python3. Log
-# files are created 0600 with O_NOFOLLOW, so a symlink planted at one of the log
-# paths is refused rather than followed, and nothing is ever written outside
-# ~/.claude/work-log/. If either budget above runs out the report is dropped
+# Reads the transcript only. No network call, no dependency beyond python3. Every
+# log path is opened with O_NOFOLLOW + O_NONBLOCK and checked to be a regular
+# file, so a symlink or a named pipe planted there is refused instead of followed
+# or waited on, and nothing is ever written outside ~/.claude/work-log/. If either budget above runs out the report is dropped
 # entirely: a partial tail scan would omit the newest events, which are the ones
 # the headline is about.
 # exit 0 required (never disturb session start or teardown)
@@ -46,9 +47,10 @@
 [ "${FORGE_SESSION_TIME_REPORT:-1}" = "0" ] && exit 0
 command -v python3 >/dev/null 2>&1 || exit 0
 
-# Two ways in, because settings.json wires this twice. The inline env form is what
-# the SessionStart entry uses: CI resolves a hook command straight to a repo path,
-# so an argument after the path would be read as part of the filename.
+# Two ways in, because settings.json wires this twice. The SessionStart entry uses
+# the inline env form, which is the form hooks/README.md documents for passing
+# configuration to a hook. --last does the same thing and is what the tests and
+# manual runs use.
 FORGE_SESSION_MODE="${FORGE_SESSION_MODE:-record}"
 [ "${1:-}" = "--last" ] && FORGE_SESSION_MODE="report"
 [ "$FORGE_SESSION_MODE" = "report" ] || FORGE_SESSION_MODE="record"
@@ -61,9 +63,11 @@ INPUT=$(cat)
 # but it also consumes stdin — piping INPUT in would feed the python source to
 # itself. Same technique as db-guard.sh / remote-command-guard.sh.
 MSG=$(FORGE_HOOK_INPUT="$INPUT" python3 <<'PYEOF' 2>/dev/null
+import errno
 import json
 import os
 import re
+import stat
 import sys
 import time
 from datetime import datetime, timezone
@@ -94,7 +98,7 @@ def parse_ts(raw):
 def open_budgeted(path, max_bytes):
     """Read at most max_bytes from the tail. Oversized transcripts must not
     stall teardown; the latest stretch lives at the tail anyway."""
-    handle = open(path, "r", encoding="utf-8", errors="replace")
+    handle = open_plain(path)
     size = os.fstat(handle.fileno()).st_size
     if size <= max_bytes:
         return handle, False
@@ -103,17 +107,39 @@ def open_budgeted(path, max_bytes):
     return handle, True
 
 
+def plain_file(fd, path):
+    """Reject anything that is not a regular file, closing the descriptor first."""
+    try:
+        if stat.S_ISREG(os.fstat(fd).st_mode):
+            return
+    except OSError:
+        pass
+    os.close(fd)
+    raise OSError(errno.EINVAL, "not a regular file", path)
+
+
 def open_private(path, append):
-    """Create at 0600 in one step and refuse to follow a symlink.
+    """Create at 0600 in one step, follow no symlink, wait on no pipe.
 
     open() + chmod() leaves the file at the umask default while it already holds
     content, and both calls follow symlinks, so a link planted at the target path
     gets its contents replaced and its mode narrowed. O_NOFOLLOW plus a creation
-    mode closes both."""
-    flags = os.O_WRONLY | os.O_CREAT | os.O_NOFOLLOW
+    mode closes both. O_NOFOLLOW says nothing about file *type* though, and a
+    named pipe planted at the same path would block the open until a reader
+    appeared, hanging every session close. O_NONBLOCK plus the fstat check below
+    turns that into an ordinary error."""
+    flags = os.O_WRONLY | os.O_CREAT | os.O_NOFOLLOW | os.O_NONBLOCK
     flags |= os.O_APPEND if append else os.O_TRUNC
-    return os.fdopen(os.open(path, flags, 0o600), "a" if append else "w",
-                     encoding="utf-8")
+    fd = os.open(path, flags, 0o600)
+    plain_file(fd, path)
+    return os.fdopen(fd, "a" if append else "w", encoding="utf-8")
+
+
+def open_plain(path):
+    """Read side of the same guard: no symlink, no pipe, no device."""
+    fd = os.open(path, os.O_RDONLY | os.O_NOFOLLOW | os.O_NONBLOCK)
+    plain_file(fd, path)
+    return os.fdopen(fd, "r", encoding="utf-8", errors="replace")
 
 
 def collect(path, max_bytes, deadline):
@@ -127,18 +153,16 @@ def collect(path, max_bytes, deadline):
     except OSError:
         return None
     events = []
-    scanned = 0
     with handle:
         for line in handle:
-            scanned += 1
-            if scanned % 2000 == 0 and time.monotonic() > deadline:
+            if time.monotonic() > deadline:
                 return None
             line = line.strip()
             if not line:
                 continue
             try:
                 record = json.loads(line)
-            except ValueError:
+            except (ValueError, RecursionError):
                 continue
             if not isinstance(record, dict):
                 continue
@@ -261,7 +285,7 @@ def rotate(path):
     try:
         if os.path.getsize(path) <= HISTORY_MAX_BYTES:
             return
-        with open(path, encoding="utf-8", errors="replace") as handle:
+        with open_plain(path) as handle:
             handle.seek(os.path.getsize(path) - HISTORY_MAX_BYTES // 2)
             handle.readline()
             kept = handle.read()
@@ -311,7 +335,7 @@ def drain():
         return []
     records = []
     try:
-        with open(claimed, encoding="utf-8") as handle:
+        with open_plain(claimed) as handle:
             for line in handle:
                 line = line.strip()
                 if not line:
@@ -395,7 +419,7 @@ def measure(payload):
     gap_seconds = env_int("FORGE_SESSION_GAP_MIN", 60, 1, 1440) * 60
     max_bytes = env_int("FORGE_SESSION_MAX_MB", 128, 1, 512) * 1024 * 1024
 
-    deadline = time.monotonic() + env_int("FORGE_SESSION_MAX_SEC", 4, 1, 30)
+    deadline = time.monotonic() + env_int("FORGE_SESSION_MAX_SEC", 4, 0, 30)
     scanned = collect(transcript, max_bytes, deadline)
     if not scanned:
         return None

--- a/hooks/session-time-report.sh
+++ b/hooks/session-time-report.sh
@@ -404,14 +404,16 @@ def owner_gone(name, prefix):
     report twice. A recycled pid reads as alive, which only delays recovery to a
     later start."""
     suffix = name[len(prefix):]
-    if not suffix.isdigit():
-        return True          # not ours to reason about, fall back to age
+    # No real pid is this large, and os.kill raises OverflowError rather than
+    # OSError on one, which would escape every guard below it.
+    if not suffix.isdigit() or len(suffix) > 7:
+        return True          # not a pid we wrote, fall back to age
     try:
         os.kill(int(suffix), 0)
     except ProcessLookupError:
         return True
-    except (OSError, ValueError):
-        return False         # alive, or owned by someone else
+    except Exception:
+        return False         # alive, owned by someone else, or unjudgeable
     return False
 
 
@@ -425,13 +427,14 @@ def stale_claims(path):
     except OSError:
         return found
     for name in names:
-        if not name.startswith(prefix) or not owner_gone(name, prefix):
-            continue
-        candidate = os.path.join(directory, name)
+        # One unreadable entry must not cost the rest of the sweep.
         try:
+            if not name.startswith(prefix) or not owner_gone(name, prefix):
+                continue
+            candidate = os.path.join(directory, name)
             if os.path.getmtime(candidate) < cutoff:
                 found.append(candidate)
-        except OSError:
+        except Exception:
             continue
     return sorted(found)
 
@@ -445,8 +448,13 @@ def drain():
     failure, and lose entries appended in between."""
     path = pending_path()
     records = []
-    for orphan in stale_claims(path):
-        records.extend(read_claim(orphan))
+    # Recovering someone else's leftovers is a courtesy. It must never be able to
+    # stop this session from claiming and reporting its own queue.
+    try:
+        for orphan in stale_claims(path):
+            records.extend(read_claim(orphan))
+    except Exception:
+        records = []
     claimed = "%s.claimed-%d" % (path, os.getpid())
     try:
         os.rename(path, claimed)

--- a/hooks/session-time-report.sh
+++ b/hooks/session-time-report.sh
@@ -1,0 +1,370 @@
+#!/bin/bash
+# session-time-report.sh - SessionEnd + SessionStart Hook
+# Tell the user when their session ended, how long it actually ran, and how much
+# went through it (prompts, tool calls, files changed).
+#
+# Analogy: the shop clock. Nobody writes down when they closed up, so the day
+# just disappears. This stamps the card on the way out and reads it back to you
+# when you next open the door.
+#
+# WHY TWO EVENTS. SessionEnd is where the numbers exist, but it cannot talk to
+# you: executeSessionEndHooks only forwards a hook's output when the hook FAILED
+# ("SessionEnd hook [cmd] failed: ..."), so a successful report is discarded
+# (verified in the shipped CLI, 2.0.x and 2.1.x). SessionStart, by contrast, is a
+# documented surface (see forge-update-check.sh). So SessionEnd measures and
+# files the report, and the next SessionStart hands it to you, once.
+#
+# Hook trigger: SessionEnd (record mode, no argument)
+#               SessionStart (report mode, argument: --last)
+# Exit codes:   0 always. Neither event may be blocked or delayed.
+# Input (stdin JSON): { session_id, transcript_path, cwd, hook_event_name, reason }
+# Output:       record mode  - stdout, plus the pending file below
+#               report mode  - stdout, the standard SessionStart channel
+# Log:          ~/.claude/work-log/session-time-<session_id>.json   (snapshot, 600)
+#               ~/.claude/work-log/session-times.jsonl              (history, 600)
+# State:        ~/.claude/work-log/.session-time-pending.json       (drained once, 600)
+# Environment:  FORGE_SESSION_TIME_REPORT=0  kill switch (both modes)
+#               FORGE_SESSION_GAP_MIN        idle minutes that start a new stretch (default 60)
+#               FORGE_SESSION_MAX_MB         transcript scan budget in MB (default 128)
+#               FORGE_SESSION_REPORT_LANG    en | ko (default: auto-detect from LANG/LC_ALL)
+#
+# Elapsed time is resume-aware (CRITICAL). Do NOT report last-minus-first over the
+# whole transcript: a session reopened with --continue measures hundreds of hours of
+# wall clock (416h observed in the wild). Timestamps are split wherever the gap
+# exceeds FORGE_SESSION_GAP_MIN, and the headline always describes the LATEST
+# stretch. Cumulative totals are appended only when they are trustworthy.
+#
+# Reads the transcript only. No network call, no dependency beyond python3.
+# exit 0 required (never disturb session start or teardown)
+
+[ "${FORGE_SESSION_TIME_REPORT:-1}" = "0" ] && exit 0
+command -v python3 >/dev/null 2>&1 || exit 0
+
+# Two ways in, because settings.json wires this twice. The inline env form is what
+# the SessionStart entry uses: CI resolves a hook command straight to a repo path,
+# so an argument after the path would be read as part of the filename.
+FORGE_SESSION_MODE="${FORGE_SESSION_MODE:-record}"
+[ "${1:-}" = "--last" ] && FORGE_SESSION_MODE="report"
+[ "$FORGE_SESSION_MODE" = "report" ] || FORGE_SESSION_MODE="record"
+export FORGE_SESSION_MODE
+
+INPUT=$(cat)
+
+# The payload travels by environment variable, not by pipe. A quoted heredoc
+# (<<'PYEOF') blocks shell expansion, which is what keeps this injection-safe,
+# but it also consumes stdin — piping INPUT in would feed the python source to
+# itself. Same technique as db-guard.sh / remote-command-guard.sh.
+MSG=$(FORGE_HOOK_INPUT="$INPUT" python3 <<'PYEOF' 2>/dev/null
+import json
+import os
+import re
+import sys
+from datetime import datetime
+
+EDIT_TOOLS = {"Edit", "Write", "NotebookEdit", "MultiEdit"}
+
+
+def env_int(name, default, low, high):
+    try:
+        value = int(os.environ.get(name, ""))
+    except ValueError:
+        return default
+    return value if low <= value <= high else default
+
+
+def parse_ts(raw):
+    if not isinstance(raw, str) or not raw:
+        return None
+    try:
+        return datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def open_budgeted(path, max_bytes):
+    """Read at most max_bytes from the tail. Oversized transcripts must not
+    stall teardown; the latest stretch lives at the tail anyway."""
+    handle = open(path, "r", encoding="utf-8", errors="replace")
+    size = os.fstat(handle.fileno()).st_size
+    if size <= max_bytes:
+        return handle, False
+    handle.seek(size - max_bytes)
+    handle.readline()  # drop the partial line the seek landed in
+    return handle, True
+
+
+def collect(path, max_bytes):
+    """Turn transcript lines into (timestamp, prompt, tool_calls, files, sidechain)."""
+    try:
+        handle, truncated = open_budgeted(path, max_bytes)
+    except OSError:
+        return None
+    events = []
+    with handle:
+        for line in handle:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                record = json.loads(line)
+            except ValueError:
+                continue
+            if not isinstance(record, dict):
+                continue
+            stamp = parse_ts(record.get("timestamp"))
+            if stamp is None:
+                continue
+            kind = record.get("type")
+            message = record.get("message")
+            prompt = 0
+            calls = 0
+            files = ()
+            # Subagent turns are not prompts the human typed; count them apart.
+            sidechain = bool(record.get("isSidechain"))
+            if isinstance(message, dict):
+                if kind == "user" and not sidechain and not record.get("isMeta"):
+                    body = message.get("content")
+                    if isinstance(body, str):
+                        prompt = 1 if body.strip() else 0
+                    elif isinstance(body, list):
+                        prompt = 1 if any(
+                            isinstance(block, dict) and block.get("type") == "text"
+                            for block in body
+                        ) else 0
+                elif kind == "assistant":
+                    touched = []
+                    for block in message.get("content") or []:
+                        if not isinstance(block, dict) or block.get("type") != "tool_use":
+                            continue
+                        calls += 1
+                        if block.get("name") in EDIT_TOOLS:
+                            payload = block.get("input")
+                            if isinstance(payload, dict):
+                                target = (payload.get("file_path")
+                                          or payload.get("notebook_path"))
+                                if isinstance(target, str) and target:
+                                    touched.append(target)
+                    files = tuple(touched)
+            events.append((stamp, prompt, calls, files, sidechain))
+    if not events:
+        return None
+    events.sort(key=lambda item: item[0])
+    return events, truncated
+
+
+def split_stretches(events, gap_seconds):
+    groups = [[events[0]]]
+    for event in events[1:]:
+        if (event[0] - groups[-1][-1][0]).total_seconds() > gap_seconds:
+            groups.append([event])
+        else:
+            groups[-1].append(event)
+    return groups
+
+
+def tally(group):
+    prompts = calls = sub_calls = 0
+    files = set()
+    for _, prompt, count, touched, sidechain in group:
+        prompts += prompt
+        if sidechain:
+            sub_calls += count
+        else:
+            calls += count
+        files.update(touched)
+    return {
+        "prompts": prompts,
+        "tool_calls": calls,
+        "subagent_tool_calls": sub_calls,
+        "files_changed": len(files),
+    }
+
+
+def human(seconds):
+    minutes = int(max(0, seconds)) // 60
+    hours, minutes = divmod(minutes, 60)
+    return "%dh %dm" % (hours, minutes) if hours else "%dm" % minutes
+
+
+def plural(count, word):
+    return "%d %s" % (count, word if count == 1 else word + "s")
+
+
+def pick_lang():
+    override = (os.environ.get("FORGE_SESSION_REPORT_LANG") or "").strip().lower()
+    if override in ("en", "ko"):
+        return override
+    locale = os.environ.get("LC_ALL") or os.environ.get("LANG") or ""
+    return "ko" if locale.lower().startswith("ko") else "en"
+
+
+def write_log(record, session_id):
+    log_dir = os.path.expanduser("~/.claude/work-log")
+    try:
+        os.makedirs(log_dir, exist_ok=True)
+    except OSError:
+        return None
+    line = json.dumps(record, ensure_ascii=False)
+    snapshot = os.path.join(log_dir, "session-time-%s.json" % session_id)
+    history = os.path.join(log_dir, "session-times.jsonl")
+    written = None
+    try:
+        with open(snapshot, "w", encoding="utf-8") as handle:
+            handle.write(line + "\n")
+        os.chmod(snapshot, 0o600)
+        written = snapshot
+    except OSError:
+        pass
+    try:
+        with open(history, "a", encoding="utf-8") as handle:
+            handle.write(line + "\n")
+        os.chmod(history, 0o600)
+    except OSError:
+        pass
+    return written
+
+
+def pending_path():
+    return os.path.expanduser("~/.claude/work-log/.session-time-pending.json")
+
+
+def stash(record):
+    """Leave the report where the next SessionStart will find it."""
+    path = pending_path()
+    try:
+        with open(path, "w", encoding="utf-8") as handle:
+            handle.write(json.dumps(record, ensure_ascii=False) + "\n")
+        os.chmod(path, 0o600)
+    except OSError:
+        pass
+
+
+def drain():
+    """Take the pending report and clear it, so it is shown exactly once."""
+    path = pending_path()
+    try:
+        with open(path, encoding="utf-8") as handle:
+            record = json.load(handle)
+    except (OSError, ValueError):
+        return None
+    try:
+        os.remove(path)
+    except OSError:
+        pass
+    return record if isinstance(record, dict) else None
+
+
+def render(record, previous):
+    lang = pick_lang()
+    stamp = record.get("ended_label") or "?"
+    span = record.get("stretch_seconds") or 0
+    active = record.get("active_seconds") or 0
+    resumed = max(0, (record.get("stretches") or 1) - 1)
+    truncated = bool(record.get("truncated"))
+    prompts = record.get("prompts") or 0
+    calls = record.get("tool_calls") or 0
+    changed = record.get("files_changed") or 0
+    sub_calls = record.get("subagent_tool_calls") or 0
+    snapshot = record.get("snapshot_path") or ""
+
+    if lang == "ko":
+        head = "[Claude Forge] %s세션 종료 %s" % ("직전 " if previous else "", stamp)
+        body = "소요 %s · 프롬프트 %d · 도구 %d · 변경 파일 %d" % (
+            human(span), prompts, calls, changed)
+        if sub_calls:
+            body += " · 서브에이전트 %d" % sub_calls
+        if truncated:
+            body += " (마지막 구간만 집계)"
+        elif resumed:
+            body += " (재개 %d회, 누적 %s)" % (resumed, human(active))
+        tail = "로그: %s"
+    else:
+        head = "[Claude Forge] %s %s" % (
+            "Previous session ended" if previous else "Session ended", stamp)
+        body = "%s elapsed · %s · %s · %s" % (
+            human(span), plural(prompts, "prompt"), plural(calls, "tool call"),
+            plural(changed, "file") + " changed")
+        if sub_calls:
+            body += " · %s" % plural(sub_calls, "subagent call")
+        if truncated:
+            body += " (latest stretch only)"
+        elif resumed:
+            body += " (resumed %dx, %s total)" % (resumed, human(active))
+        tail = "Log: %s"
+
+    lines = [head, body]
+    if snapshot:
+        home = os.path.expanduser("~")
+        lines.append(tail % (snapshot.replace(home, "~", 1)
+                             if snapshot.startswith(home) else snapshot))
+    return "\n".join(lines)
+
+
+def measure(payload):
+    session_id = payload.get("session_id") or ""
+    # The id becomes a filename, so strip anything that could escape the directory.
+    session_id = re.sub(r"[^A-Za-z0-9_-]", "_", session_id)[:96]
+    if not session_id:
+        return None
+
+    transcript = os.path.expanduser(payload.get("transcript_path") or "")
+    if not transcript or not os.path.isfile(transcript):
+        return None
+
+    gap_seconds = env_int("FORGE_SESSION_GAP_MIN", 60, 1, 1440) * 60
+    max_bytes = env_int("FORGE_SESSION_MAX_MB", 128, 1, 4096) * 1024 * 1024
+
+    scanned = collect(transcript, max_bytes)
+    if not scanned:
+        return None
+    events, truncated = scanned
+
+    stretches = split_stretches(events, gap_seconds)
+    current = stretches[-1]
+    counts = tally(current)
+    started = current[0][0]
+    ended = datetime.now().astimezone()
+    span = int((current[-1][0] - started).total_seconds())
+    active = sum(int((g[-1][0] - g[0][0]).total_seconds()) for g in stretches)
+
+    record = {
+        "event": "session_time_report",
+        "session_id": session_id,
+        "cwd": payload.get("cwd") or "",
+        "reason": payload.get("reason") or "",
+        "ended_at": ended.isoformat(),
+        "ended_label": ("%s %s" % (ended.strftime("%H:%M"), ended.strftime("%Z"))).strip(),
+        "stretch_started_at": started.astimezone().isoformat(),
+        "stretch_ended_at": current[-1][0].astimezone().isoformat(),
+        "stretch_seconds": span,
+        "stretches": len(stretches),
+        "active_seconds": active,
+        "truncated": truncated,
+        "gap_minutes": gap_seconds // 60,
+    }
+    record.update(counts)
+    record["snapshot_path"] = write_log(record, session_id) or ""
+    stash(record)
+    return record
+
+
+try:
+    if os.environ.get("FORGE_SESSION_MODE") == "report":
+        stashed = drain()
+        text = render(stashed, previous=True) if stashed else None
+    else:
+        incoming = json.loads(os.environ.get("FORGE_HOOK_INPUT") or "{}")
+        measured = measure(incoming) if isinstance(incoming, dict) else None
+        text = render(measured, previous=False) if measured else None
+    if text:
+        sys.stdout.write(text + "\n")
+except Exception:
+    sys.exit(0)
+PYEOF
+)
+
+if [ -n "$MSG" ]; then
+    printf '%s\n' "$MSG"
+fi
+
+exit 0

--- a/install.ps1
+++ b/install.ps1
@@ -73,7 +73,7 @@ function Write-UpgradeSummary {
     Write-Host "  Target        : $ClaudeDir"
     Write-Host ""
     Write-Host "  Expected counts:"
-    Write-Host "    - 16 agents, 32 skills (23 native + 8 moved from commands + 1 vendored: loop-forge), 35 commands, 14 rules, 21 hooks + 9 opt-in examples"
+    Write-Host "    - 16 agents, 32 skills (23 native + 8 moved from commands + 1 vendored: loop-forge), 35 commands, 14 rules, 22 hooks + 9 opt-in examples"
     Write-Host ""
     Write-Host "  Next steps:"
     Write-Host "    1. Review MIGRATION.md for detailed changes"

--- a/install.sh
+++ b/install.sh
@@ -169,7 +169,7 @@ print_upgrade_summary() {
     echo "  Target        : $CLAUDE_DIR"
     echo ""
     echo "  Expected counts:"
-    echo "    - 16 agents, 33 skills (24 native + 8 moved from commands + 1 vendored: loop-forge), 35 commands, 14 rules, 21 hooks + 9 opt-in examples"
+    echo "    - 16 agents, 33 skills (24 native + 8 moved from commands + 1 vendored: loop-forge), 35 commands, 14 rules, 22 hooks + 9 opt-in examples"
     echo ""
     echo "  Next steps:"
     echo "    1. Review MIGRATION.md for detailed changes"

--- a/scripts/tests/test_session_time_report.sh
+++ b/scripts/tests/test_session_time_report.sh
@@ -1,0 +1,202 @@
+#!/bin/bash
+# session-time-report.sh regression: resume-aware elapsed time, counts, output
+# channel, log file, and the defensive paths that must never break teardown.
+# Run: bash scripts/tests/test_session_time_report.sh
+set -uo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+HOOK="$ROOT/hooks/session-time-report.sh"
+[ -r "$HOOK" ] || { echo "FAIL: hooks/session-time-report.sh missing"; exit 1; }
+PASS=0; FAIL=0
+ok(){ printf '  ok   %s\n' "$1"; PASS=$((PASS+1)); }
+no(){ printf '  FAIL %s\n' "$1"; FAIL=$((FAIL+1)); }
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+# The hook writes under ~/.claude/work-log; relocate HOME so the suite cannot
+# touch the developer's real logs.
+export HOME="$WORK/home"
+mkdir -p "$HOME"
+
+bash -n "$HOOK" && ok "parses with bash -n" || no "parses with bash -n"
+[ -x "$HOOK" ] && ok "executable bit set" || no "executable bit set"
+MODE=$(cd "$ROOT" && git ls-files -s hooks/session-time-report.sh 2>/dev/null | awk '{print $1}')
+[ "$MODE" = "100755" ] && ok "git index mode 100755" || no "git index mode 100755 (got '${MODE:-untracked}')"
+
+# --- fixture: two stretches split by a 5 h gap -----------------------------
+# Stretch A: 3 turns over 40 min. Gap: 5 h. Stretch B: 30 min, 2 prompts,
+# 3 tool calls, 2 distinct files edited (one file touched twice).
+TRANSCRIPT="$WORK/session.jsonl"
+python3 - "$TRANSCRIPT" <<'PY'
+import json, sys
+from datetime import datetime, timedelta, timezone
+
+base = datetime(2026, 9, 1, 1, 0, 0, tzinfo=timezone.utc)
+rows = []
+
+def at(minutes):
+    return (base + timedelta(minutes=minutes)).isoformat().replace("+00:00", "Z")
+
+def user(minutes, text="hello"):
+    rows.append({"type": "user", "timestamp": at(minutes),
+                 "message": {"content": text}})
+
+def assistant(minutes, tools):
+    blocks = []
+    for name, path in tools:
+        block = {"type": "tool_use", "name": name, "input": {}}
+        if path:
+            block["input"]["file_path"] = path
+        blocks.append(block)
+    rows.append({"type": "assistant", "timestamp": at(minutes),
+                 "message": {"content": blocks}})
+
+# stretch A: 0 -> 40 min
+user(0)
+assistant(5, [("Bash", None)])
+user(20)
+assistant(40, [("Edit", "/tmp/a.txt")])
+
+# 5 h gap, then stretch B: 340 -> 370 min
+user(340)
+assistant(345, [("Bash", None), ("Edit", "/tmp/b.txt")])
+user(360)
+assistant(370, [("Write", "/tmp/b.txt")])
+
+# noise that must be ignored: meta turn, sidechain prompt, unparseable line
+rows.append({"type": "user", "timestamp": at(365), "isMeta": True,
+             "message": {"content": "meta"}})
+rows.append({"type": "user", "timestamp": at(366), "isSidechain": True,
+             "message": {"content": "subagent prompt"}})
+
+with open(sys.argv[1], "w") as fh:
+    for row in rows:
+        fh.write(json.dumps(row) + "\n")
+    fh.write("this line is not json\n")
+PY
+
+payload(){ printf '{"session_id":"%s","transcript_path":"%s","cwd":"/tmp","hook_event_name":"SessionEnd","reason":"exit"}' "$1" "$2"; }
+
+run(){ payload "$1" "$2" | FORGE_SESSION_REPORT_LANG=en "$HOOK"; }
+
+# --- output channel: stdout carries the report, stderr stays clean ----------
+# SessionEnd discards a successful hook's output, so the visible surface is the
+# SessionStart replay tested further down. stdout is what both modes write to.
+ERR=$(run sess-a "$TRANSCRIPT" 2>&1 >/dev/null)
+OUT=$(run sess-a "$TRANSCRIPT" 2>/dev/null)
+[ -z "$ERR" ] && ok "stderr stays clean" || no "stderr stays clean (got '$ERR')"
+case "$OUT" in "[Claude Forge] Session ended"*) ok "stdout carries a tagged report";;
+  *) no "stdout carries a tagged report (got '$OUT')";; esac
+ERR="$OUT"   # the assertions below read the rendered report
+
+# --- the core invariant: report the latest stretch, not the whole span ------
+# Whole transcript spans 370 min (6h 10m). Latest stretch is 30 min.
+case "$ERR" in *"30m elapsed"*) ok "elapsed = latest stretch, not whole span";;
+  *) no "elapsed = latest stretch, not whole span (got '$ERR')";; esac
+case "$ERR" in *"6h"*) no "does not leak the resumed wall-clock span";;
+  *) ok "does not leak the resumed wall-clock span";; esac
+case "$ERR" in *"resumed 1x"*) ok "resume count reported";;
+  *) no "resume count reported (got '$ERR')";; esac
+
+# --- counts are scoped to that stretch --------------------------------------
+case "$ERR" in *"2 prompts"*) ok "prompts counted (meta and sidechain excluded)";;
+  *) no "prompts counted (got '$ERR')";; esac
+case "$ERR" in *"3 tool calls"*) ok "tool calls counted";;
+  *) no "tool calls counted (got '$ERR')";; esac
+case "$ERR" in *"1 file changed"*) ok "changed files deduplicated";;
+  *) no "changed files deduplicated (got '$ERR')";; esac
+
+# --- a wider gap threshold merges the stretches ------------------------------
+WIDE=$(payload sess-w "$TRANSCRIPT" | FORGE_SESSION_GAP_MIN=600 FORGE_SESSION_REPORT_LANG=en "$HOOK" 2>/dev/null)
+case "$WIDE" in *"6h 10m elapsed"*) ok "FORGE_SESSION_GAP_MIN widens the stretch";;
+  *) no "FORGE_SESSION_GAP_MIN widens the stretch (got '$WIDE')";; esac
+
+# --- Korean surface ----------------------------------------------------------
+KO=$(payload sess-k "$TRANSCRIPT" | FORGE_SESSION_REPORT_LANG=ko "$HOOK" 2>/dev/null)
+case "$KO" in *"세션 종료"*) ok "ko locale renders Korean";;
+  *) no "ko locale renders Korean (got '$KO')";; esac
+
+# --- log file ----------------------------------------------------------------
+SNAP="$HOME/.claude/work-log/session-time-sess-a.json"
+[ -f "$SNAP" ] && ok "snapshot log written" || no "snapshot log written"
+[ -f "$HOME/.claude/work-log/session-times.jsonl" ] && ok "history log appended" \
+  || no "history log appended"
+PERM=$(ls -l "$SNAP" 2>/dev/null | cut -c1-10)
+[ "$PERM" = "-rw-------" ] && ok "snapshot is mode 600" || no "snapshot is mode 600 (got '$PERM')"
+python3 - "$SNAP" <<'PY' && ok "log carries the expected fields" || no "log carries the expected fields"
+import json, sys
+d = json.load(open(sys.argv[1]))
+need = ["event", "session_id", "ended_at", "stretch_seconds", "stretches",
+        "active_seconds", "truncated", "prompts", "tool_calls", "files_changed"]
+missing = [k for k in need if k not in d]
+assert not missing, missing
+assert d["stretches"] == 2, d["stretches"]
+assert d["stretch_seconds"] == 1800, d["stretch_seconds"]
+assert d["prompts"] == 2 and d["tool_calls"] == 3 and d["files_changed"] == 1, d
+PY
+
+# --- report mode: SessionStart replays the last session exactly once ---------
+PENDING="$HOME/.claude/work-log/.session-time-pending.json"
+run sess-p "$TRANSCRIPT" >/dev/null 2>&1
+[ -f "$PENDING" ] && ok "record mode leaves a pending report" || no "record mode leaves a pending report"
+
+REPLAY=$(printf '{"session_id":"new","source":"startup"}' | FORGE_SESSION_REPORT_LANG=en "$HOOK" --last 2>/dev/null)
+case "$REPLAY" in "[Claude Forge] Previous session ended"*) ok "report mode replays the previous session";;
+  *) no "report mode replays the previous session (got '$REPLAY')";; esac
+case "$REPLAY" in *"30m elapsed"*) ok "replay keeps the measured numbers";;
+  *) no "replay keeps the measured numbers (got '$REPLAY')";; esac
+[ -f "$PENDING" ] && no "pending report is drained" || ok "pending report is drained"
+
+AGAIN=$(printf '{"session_id":"new"}' | FORGE_SESSION_REPORT_LANG=en "$HOOK" --last 2>&1)
+[ -z "$AGAIN" ] && ok "report mode is silent with nothing pending" \
+  || no "report mode is silent with nothing pending (got '$AGAIN')"
+
+# settings.json wires report mode through the inline env form, not an argument,
+# because CI resolves a hook command straight to a repo path.
+run sess-e "$TRANSCRIPT" >/dev/null 2>&1
+ENVMODE=$(printf '{"session_id":"new"}' | FORGE_SESSION_MODE=report FORGE_SESSION_REPORT_LANG=en "$HOOK" 2>/dev/null)
+case "$ENVMODE" in "[Claude Forge] Previous session ended"*) ok "FORGE_SESSION_MODE=report selects report mode";;
+  *) no "FORGE_SESSION_MODE=report selects report mode (got '$ENVMODE')";; esac
+
+# both wirings must resolve to a tracked file in this repo
+python3 - "$ROOT" <<'PYCHK' && ok "settings.json wiring resolves to this hook" || no "settings.json wiring resolves to this hook"
+import json, pathlib, sys
+root = pathlib.Path(sys.argv[1])
+settings = json.loads((root / "settings.json").read_text())
+found = {"SessionEnd": False, "SessionStart": False}
+for event, groups in settings.get("hooks", {}).items():
+    if event not in found:
+        continue
+    for group in groups:
+        for hook in group.get("hooks", []):
+            command = hook.get("command", "")
+            if "session-time-report.sh" not in command:
+                continue
+            found[event] = True
+            path = command.split()[-1]
+            assert path.startswith("~/.claude/"), command
+            assert (root / path[len("~/.claude/"):]).is_file(), command
+assert all(found.values()), found
+PYCHK
+
+# --- session_id is sanitized before it becomes a filename --------------------
+payload "../../escaped" "$TRANSCRIPT" | "$HOOK" >/dev/null 2>&1
+[ -e "$HOME/.claude/escaped.json" ] && no "session_id traversal blocked" \
+  || ok "session_id traversal blocked"
+
+# --- defensive paths: never break teardown -----------------------------------
+quiet(){ # command must exit 0 and print nothing on either stream
+  local label="$1"; shift
+  local out; out=$("$@" 2>&1); local rc=$?
+  if [ $rc -eq 0 ] && [ -z "$out" ]; then ok "$label"; else no "$label (rc=$rc out='$out')"; fi
+}
+: > "$WORK/empty.jsonl"
+payload sess-kill "$TRANSCRIPT" > "$WORK/kill.json"
+
+quiet "empty stdin is silent"        sh -c "printf '' | '$HOOK'"
+quiet "malformed json is silent"     sh -c "printf 'not json' | '$HOOK'"
+quiet "json array is silent"         sh -c "printf '[1,2,3]' | '$HOOK'"
+quiet "missing transcript is silent" sh -c "printf '{\"session_id\":\"x\",\"transcript_path\":\"/nope/none.jsonl\"}' | '$HOOK'"
+quiet "kill switch silences it"      sh -c "FORGE_SESSION_TIME_REPORT=0 '$HOOK' < '$WORK/kill.json'"
+quiet "empty transcript is silent"   sh -c "printf '{\"session_id\":\"e\",\"transcript_path\":\"$WORK/empty.jsonl\"}' | '$HOOK'"
+
+echo "PASS=$PASS FAIL=$FAIL"; exit $((FAIL > 0))

--- a/scripts/tests/test_session_time_report.sh
+++ b/scripts/tests/test_session_time_report.sh
@@ -351,6 +351,15 @@ FRESH=$(printf '{"session_id":"n"}' | HOME="$ORPH" FORGE_SESSION_REPORT_LANG=en 
 [ -z "$FRESH" ] && ok "a fresh claim is left to its owner" \
   || no "a fresh claim is left to its owner (got '$FRESH')"
 
+# Age alone is settable by the same user, so a live drain must be identified by
+# its pid, not by how old its claim looks.
+payload or-3 "$TRANSCRIPT" | HOME="$ORPH" "$HOOK" >/dev/null 2>&1
+mv "$OWL/.session-time-pending.jsonl" "$OWL/.session-time-pending.jsonl.claimed-$$"
+touch -t 202601010000 "$OWL/.session-time-pending.jsonl.claimed-$$"
+LIVE=$(printf '{"session_id":"n"}' | HOME="$ORPH" FORGE_SESSION_REPORT_LANG=en "$HOOK" --last 2>&1)
+[ -z "$LIVE" ] && ok "a live owner keeps its claim however old it looks" \
+  || no "a live owner keeps its claim however old it looks (got '$LIVE')"
+
 # --- a named pipe planted at a log path must not stall the session ----------
 # O_NOFOLLOW only refuses symlinks. A FIFO is a different file type, and opening
 # one blocks until a reader appears, which would hang every close and open.

--- a/scripts/tests/test_session_time_report.sh
+++ b/scripts/tests/test_session_time_report.sh
@@ -360,6 +360,25 @@ LIVE=$(printf '{"session_id":"n"}' | HOME="$ORPH" FORGE_SESSION_REPORT_LANG=en "
 [ -z "$LIVE" ] && ok "a live owner keeps its claim however old it looks" \
   || no "a live owner keeps its claim however old it looks (got '$LIVE')"
 
+# A planted claim whose suffix is not a usable pid must not be able to silence
+# every future drain. os.kill raises OverflowError past 2**31, which is neither
+# OSError nor ValueError.
+POIS="$WORK/pidpoison"
+mkdir -p "$POIS/.claude/work-log"
+: > "$POIS/.claude/work-log/.session-time-pending.jsonl.claimed-99999999999999999999"
+payload pp-1 "$TRANSCRIPT" | HOME="$POIS" "$HOOK" >/dev/null 2>&1
+PIDPOISON=$(printf '{"session_id":"n"}' | HOME="$POIS" FORGE_SESSION_REPORT_LANG=en "$HOOK" --last 2>/dev/null)
+case "$PIDPOISON" in "[Claude Forge] Previous session ended"*) ok "an unusable pid suffix cannot silence the drain";;
+  *) no "an unusable pid suffix cannot silence the drain (got '$PIDPOISON')";; esac
+
+for SUFFIX in 0 -1 abc 1e9 ""; do
+  : > "$POIS/.claude/work-log/.session-time-pending.jsonl.claimed-$SUFFIX"
+done
+payload pp-2 "$TRANSCRIPT" | HOME="$POIS" "$HOOK" >/dev/null 2>&1
+ODD=$(printf '{"session_id":"n"}' | HOME="$POIS" FORGE_SESSION_REPORT_LANG=en "$HOOK" --last 2>/dev/null)
+case "$ODD" in "[Claude Forge] Previous session ended"*) ok "odd pid suffixes are survivable";;
+  *) no "odd pid suffixes are survivable (got '$ODD')";; esac
+
 # --- a named pipe planted at a log path must not stall the session ----------
 # O_NOFOLLOW only refuses symlinks. A FIFO is a different file type, and opening
 # one blocks until a reader appears, which would hang every close and open.

--- a/scripts/tests/test_session_time_report.sh
+++ b/scripts/tests/test_session_time_report.sh
@@ -279,6 +279,78 @@ STARVE=$(payload sess-sv "$FEWBIG" | FORGE_SESSION_MAX_SEC=0 "$HOOK" 2>&1)
 [ -z "$STARVE" ] && ok "the budget is checked on every line, not every Nth" \
   || no "the budget is checked on every line, not every Nth (got '$STARVE')"
 
+# One enormous line has no "next line" for a between-lines check to fire on, so
+# the budget has to be sampled inside the read, not around it.
+ONEBIG="$WORK/one-big.jsonl"
+python3 - "$ONEBIG" <<'PYBIG1'
+import json, sys
+with open(sys.argv[1], "w") as fh:
+    fh.write(json.dumps({"type": "user", "timestamp": "2026-09-01T01:00:00Z",
+                         "message": {"content": "x" * (40 * 1024 * 1024)}}) + "\n")
+PYBIG1
+HUGE=$(payload sess-hg "$ONEBIG" | FORGE_SESSION_MAX_SEC=0 timeout 20 "$HOOK" 2>&1)
+[ -z "$HUGE" ] && ok "the budget is sampled inside a single huge line" \
+  || no "the budget is sampled inside a single huge line (got '$HUGE')"
+
+# An over-long record is skipped, but it must not swallow the lines around it.
+MIXBIG="$WORK/mix-big.jsonl"
+python3 - "$MIXBIG" <<'PYBIG2'
+import json, sys
+rows = [
+    {"type": "user", "timestamp": "2026-09-01T01:00:00Z", "message": {"content": "hello"}},
+    {"type": "user", "timestamp": "2026-09-01T01:01:00Z",
+     "message": {"content": "y" * (20 * 1024 * 1024)}},
+    {"type": "assistant", "timestamp": "2026-09-01T01:05:00Z",
+     "message": {"content": [{"type": "tool_use", "name": "Bash", "input": {}}]}},
+    {"type": "user", "timestamp": "2026-09-01T01:09:00Z", "message": {"content": "bye"}},
+]
+with open(sys.argv[1], "w") as fh:
+    for row in rows:
+        fh.write(json.dumps(row) + "\n")
+PYBIG2
+SKIPPED=$(payload sess-sk "$MIXBIG" | FORGE_SESSION_REPORT_LANG=en "$HOOK" 2>/dev/null)
+case "$SKIPPED" in *"2 prompts"*"1 tool call"*) ok "an over-long record is skipped, neighbours still parse";;
+  *) no "an over-long record is skipped, neighbours still parse (got '$SKIPPED')";; esac
+
+# --- a poisoned queue line must not cost the whole batch ---------------------
+# drain() parses the queue with its own loop. A line that raises something other
+# than ValueError used to escape it, losing every queued announcement and leaving
+# the claimed file behind.
+POISON="$WORK/poison"
+mkdir -p "$POISON"
+payload pz-1 "$TRANSCRIPT" | HOME="$POISON" "$HOOK" >/dev/null 2>&1
+python3 - "$POISON/.claude/work-log/.session-time-pending.jsonl" <<'PYPOISON'
+import sys
+with open(sys.argv[1], "a") as fh:
+    fh.write("[" * 200000 + "]" * 200000 + "\n")
+PYPOISON
+SURVIVE=$(printf '{"session_id":"n"}' | HOME="$POISON" FORGE_SESSION_REPORT_LANG=en "$HOOK" --last 2>/dev/null)
+case "$SURVIVE" in "[Claude Forge] Previous session ended"*) ok "a poisoned queue line does not lose the batch";;
+  *) no "a poisoned queue line does not lose the batch (got '$SURVIVE')";; esac
+POISONLEFT=0
+for stray in "$POISON/.claude/work-log/"*.claimed-*; do
+  [ -e "$stray" ] && POISONLEFT=$((POISONLEFT+1))
+done
+[ "$POISONLEFT" = "0" ] && ok "a poisoned batch leaves no claim behind" \
+  || no "a poisoned batch leaves no claim behind ($POISONLEFT)"
+
+# --- a claim orphaned by a dead run is picked back up, a live one is not -----
+ORPH="$WORK/orphan"
+mkdir -p "$ORPH/.claude/work-log"
+OWL="$ORPH/.claude/work-log"
+payload or-1 "$TRANSCRIPT" | HOME="$ORPH" "$HOOK" >/dev/null 2>&1
+mv "$OWL/.session-time-pending.jsonl" "$OWL/.session-time-pending.jsonl.claimed-99999"
+touch -t 202601010000 "$OWL/.session-time-pending.jsonl.claimed-99999"
+RECLAIM=$(printf '{"session_id":"n"}' | HOME="$ORPH" FORGE_SESSION_REPORT_LANG=en "$HOOK" --last 2>/dev/null)
+case "$RECLAIM" in "[Claude Forge] Previous session ended"*) ok "a stale claim is recovered";;
+  *) no "a stale claim is recovered (got '$RECLAIM')";; esac
+
+payload or-2 "$TRANSCRIPT" | HOME="$ORPH" "$HOOK" >/dev/null 2>&1
+mv "$OWL/.session-time-pending.jsonl" "$OWL/.session-time-pending.jsonl.claimed-88888"
+FRESH=$(printf '{"session_id":"n"}' | HOME="$ORPH" FORGE_SESSION_REPORT_LANG=en "$HOOK" --last 2>&1)
+[ -z "$FRESH" ] && ok "a fresh claim is left to its owner" \
+  || no "a fresh claim is left to its owner (got '$FRESH')"
+
 # --- a named pipe planted at a log path must not stall the session ----------
 # O_NOFOLLOW only refuses symlinks. A FIFO is a different file type, and opening
 # one blocks until a reader appears, which would hang every close and open.

--- a/scripts/tests/test_session_time_report.sh
+++ b/scripts/tests/test_session_time_report.sh
@@ -150,8 +150,8 @@ AGAIN=$(printf '{"session_id":"new"}' | FORGE_SESSION_REPORT_LANG=en "$HOOK" --l
 [ -z "$AGAIN" ] && ok "report mode is silent with nothing pending" \
   || no "report mode is silent with nothing pending (got '$AGAIN')"
 
-# settings.json wires report mode through the inline env form, not an argument,
-# because CI resolves a hook command straight to a repo path.
+# settings.json wires report mode through the inline env form; --last is the same
+# switch for manual runs. Both must select report mode.
 run sess-e "$TRANSCRIPT" >/dev/null 2>&1
 ENVMODE=$(printf '{"session_id":"new"}' | FORGE_SESSION_MODE=report FORGE_SESSION_REPORT_LANG=en "$HOOK" 2>/dev/null)
 case "$ENVMODE" in "[Claude Forge] Previous session ended"*) ok "FORGE_SESSION_MODE=report selects report mode";;
@@ -257,6 +257,47 @@ CM=$(ls -l "$CANARY" | cut -c1-10)
 TIMEBOX=$(payload sess-t "$TRANSCRIPT" | FORGE_SESSION_MAX_SEC=1 FORGE_SESSION_REPORT_LANG=en "$HOOK" 2>/dev/null)
 case "$TIMEBOX" in "[Claude Forge]"*) ok "a small transcript still fits the time budget";;
   *) no "a small transcript still fits the time budget (got '$TIMEBOX')";; esac
+
+# With no budget at all the scan must abandon rather than report a partial read.
+# Deleting the deadline check makes this assertion go red, which is the point:
+# the previous version sampled the clock every 2000 lines and was never exercised.
+SPENT=$(payload sess-d "$TRANSCRIPT" | FORGE_SESSION_MAX_SEC=0 "$HOOK" 2>&1)
+[ -z "$SPENT" ] && ok "an exhausted time budget drops the report" \
+  || no "an exhausted time budget drops the report (got '$SPENT')"
+
+# The starvation case: a transcript of a few very large lines. A check that only
+# samples every N lines never runs here, so the budget would be ignored entirely.
+FEWBIG="$WORK/few-big.jsonl"
+python3 - "$FEWBIG" <<'PYFEW'
+import json, sys
+with open(sys.argv[1], "w") as fh:
+    for i in range(3):
+        fh.write(json.dumps({"type": "user", "timestamp": "2026-09-01T01:0%d:00Z" % i,
+                             "message": {"content": "x" * 200000}}) + "\n")
+PYFEW
+STARVE=$(payload sess-sv "$FEWBIG" | FORGE_SESSION_MAX_SEC=0 "$HOOK" 2>&1)
+[ -z "$STARVE" ] && ok "the budget is checked on every line, not every Nth" \
+  || no "the budget is checked on every line, not every Nth (got '$STARVE')"
+
+# --- a named pipe planted at a log path must not stall the session ----------
+# O_NOFOLLOW only refuses symlinks. A FIFO is a different file type, and opening
+# one blocks until a reader appears, which would hang every close and open.
+FIFOH="$WORK/fifo"
+mkdir -p "$FIFOH/.claude/work-log"
+mkfifo "$FIFOH/.claude/work-log/session-times.jsonl"
+mkfifo "$FIFOH/.claude/work-log/.session-time-pending.jsonl"
+mkfifo "$FIFOH/.claude/work-log/session-time-sess-fifo.json"
+payload sess-fifo "$TRANSCRIPT" | HOME="$FIFOH" timeout 8 "$HOOK" >/dev/null 2>&1
+[ $? -ne 124 ] && ok "a FIFO log path does not hang record mode" || no "a FIFO log path does not hang record mode"
+printf '{"session_id":"n"}' | HOME="$FIFOH" timeout 8 "$HOOK" --last >/dev/null 2>&1
+[ $? -ne 124 ] && ok "a FIFO queue does not hang report mode" || no "a FIFO queue does not hang report mode"
+
+# a FIFO transcript must be ignored, not read
+mkfifo "$WORK/fifo-transcript.jsonl"
+FT=$(payload sess-ft "$WORK/fifo-transcript.jsonl" | timeout 8 "$HOOK" 2>&1)
+FTRC=$?
+{ [ $FTRC -ne 124 ] && [ -z "$FT" ]; } && ok "a FIFO transcript is ignored" \
+  || no "a FIFO transcript is ignored (rc=$FTRC out='$FT')"
 
 # --- defensive paths: never break teardown -----------------------------------
 quiet(){ # command must exit 0 and print nothing on either stream

--- a/scripts/tests/test_session_time_report.sh
+++ b/scripts/tests/test_session_time_report.sh
@@ -135,7 +135,7 @@ assert d["prompts"] == 2 and d["tool_calls"] == 3 and d["files_changed"] == 1, d
 PY
 
 # --- report mode: SessionStart replays the last session exactly once ---------
-PENDING="$HOME/.claude/work-log/.session-time-pending.json"
+PENDING="$HOME/.claude/work-log/.session-time-pending.jsonl"
 run sess-p "$TRANSCRIPT" >/dev/null 2>&1
 [ -f "$PENDING" ] && ok "record mode leaves a pending report" || no "record mode leaves a pending report"
 
@@ -182,6 +182,81 @@ PYCHK
 payload "../../escaped" "$TRANSCRIPT" | "$HOOK" >/dev/null 2>&1
 [ -e "$HOME/.claude/escaped.json" ] && no "session_id traversal blocked" \
   || ok "session_id traversal blocked"
+
+# --- concurrent sessions: no announcement is silently dropped ----------------
+# A single overwritten pending file loses every session but the last, which is a
+# normal pattern for anyone running several terminals or worktrees at once.
+CONC="$WORK/conc"
+mkdir -p "$CONC"
+payload conc-a "$TRANSCRIPT" | HOME="$CONC" "$HOOK" >/dev/null 2>&1
+payload conc-b "$TRANSCRIPT" | HOME="$CONC" "$HOOK" >/dev/null 2>&1
+QUEUED=$(printf '{"session_id":"new"}' | HOME="$CONC" FORGE_SESSION_REPORT_LANG=en "$HOOK" --last 2>/dev/null)
+case "$QUEUED" in *"1 earlier session in the log"*) ok "queued sessions are all accounted for";;
+  *) no "queued sessions are all accounted for (got '$QUEUED')";; esac
+[ -f "$CONC/.claude/work-log/.session-time-pending.jsonl" ] && no "queue is claimed on drain" \
+  || ok "queue is claimed on drain"
+LEFT=0
+for stray in "$CONC/.claude/work-log/"*.claimed-*; do
+  [ -e "$stray" ] && LEFT=$((LEFT+1))
+done
+[ "$LEFT" = "0" ] && ok "no claimed leftovers" || no "no claimed leftovers ($LEFT)"
+
+# --- a transcript mixing naive and aware timestamps still reports -------------
+MIXED="$WORK/mixed.jsonl"
+python3 - "$MIXED" <<'PYMIX'
+import json, sys
+rows = [
+    {"type": "user", "timestamp": "2026-09-01T01:00:00", "message": {"content": "hi"}},
+    {"type": "assistant", "timestamp": "2026-09-01T01:10:00Z",
+     "message": {"content": [{"type": "tool_use", "name": "Bash", "input": {}}]}},
+]
+with open(sys.argv[1], "w") as fh:
+    for row in rows:
+        fh.write(json.dumps(row) + "\n")
+PYMIX
+MIX=$(payload sess-mx "$MIXED" | FORGE_SESSION_REPORT_LANG=en "$HOOK" 2>/dev/null)
+case "$MIX" in "[Claude Forge] Session ended"*) ok "naive and aware timestamps mix cleanly";;
+  *) no "naive and aware timestamps mix cleanly (got '$MIX')";; esac
+
+# --- the history file has a ceiling -----------------------------------------
+BIG="$WORK/big"
+mkdir -p "$BIG/.claude/work-log"
+python3 - "$BIG/.claude/work-log/session-times.jsonl" <<'PYBIG'
+import sys
+with open(sys.argv[1], "w") as fh:
+    fh.write(('{"filler":"%s"}\n' % ("x" * 400)) * 6000)   # ~2.4 MB
+PYBIG
+payload sess-rot "$TRANSCRIPT" | HOME="$BIG" "$HOOK" >/dev/null 2>&1
+SIZE=$(wc -c < "$BIG/.claude/work-log/session-times.jsonl")
+[ "$SIZE" -lt 1048576 ] && ok "history rotates under its cap" || no "history rotates under its cap ($SIZE bytes)"
+tail -1 "$BIG/.claude/work-log/session-times.jsonl" | grep -q session_time_report \
+  && ok "rotation keeps the newest record" || no "rotation keeps the newest record"
+
+# --- writes are private and never follow a symlink ---------------------------
+FRESH="$WORK/fresh"
+mkdir -p "$FRESH"
+payload sess-f "$TRANSCRIPT" | HOME="$FRESH" "$HOOK" >/dev/null 2>&1
+DIRPERM=$(ls -ld "$FRESH/.claude/work-log" 2>/dev/null | cut -c1-10)
+[ "$DIRPERM" = "drwx------" ] && ok "log directory created private" \
+  || no "log directory created private (got '$DIRPERM')"
+for f in "session-time-sess-f.json" "session-times.jsonl" ".session-time-pending.jsonl"; do
+  M=$(ls -l "$FRESH/.claude/work-log/$f" 2>/dev/null | cut -c1-10)
+  [ "$M" = "-rw-------" ] && ok "$f created 600" || no "$f created 600 (got '$M')"
+done
+
+CANARY="$WORK/canary"
+printf 'PRISTINE\n' > "$CANARY"; chmod 644 "$CANARY"
+ln -s "$CANARY" "$FRESH/.claude/work-log/session-time-symsess.json"
+payload symsess "$TRANSCRIPT" | HOME="$FRESH" "$HOOK" >/dev/null 2>&1
+[ "$(cat "$CANARY")" = "PRISTINE" ] && ok "symlinked log path is not followed" \
+  || no "symlinked log path is not followed (canary was overwritten)"
+CM=$(ls -l "$CANARY" | cut -c1-10)
+[ "$CM" = "-rw-r--r--" ] && ok "symlink target keeps its mode" || no "symlink target keeps its mode (got '$CM')"
+
+# --- the scan gives up rather than reporting a partial tail ------------------
+TIMEBOX=$(payload sess-t "$TRANSCRIPT" | FORGE_SESSION_MAX_SEC=1 FORGE_SESSION_REPORT_LANG=en "$HOOK" 2>/dev/null)
+case "$TIMEBOX" in "[Claude Forge]"*) ok "a small transcript still fits the time budget";;
+  *) no "a small transcript still fits the time budget (got '$TIMEBOX')";; esac
 
 # --- defensive paths: never break teardown -----------------------------------
 quiet(){ # command must exit 0 and print nothing on either stream

--- a/settings.json
+++ b/settings.json
@@ -146,11 +146,31 @@
         ]
       },
       {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "FORGE_SESSION_MODE=report ~/.claude/hooks/session-time-report.sh",
+            "timeout": 5
+          }
+        ]
+      },
+      {
         "matcher": "compact",
         "hooks": [
           {
             "type": "command",
             "command": "~/.claude/hooks/post-compact-restore.sh"
+          }
+        ]
+      }
+    ],
+    "SessionEnd": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/session-time-report.sh",
+            "timeout": 10
           }
         ]
       }

--- a/web/_og.html
+++ b/web/_og.html
@@ -40,7 +40,7 @@ h1 em{font-style:normal;background:linear-gradient(120deg,#FFE27A,#FF7A18);
     <div class="left">
       <div class="eyebrow">⭐ Free &amp; open source · MIT</div>
       <h1>Claude Code,<br><em>fully equipped.</em></h1>
-      <p class="sub"><b>16 agents · 35 commands · 33 skills · 21 safety hooks</b> — in one install. No signup, no card.</p>
+      <p class="sub"><b>16 agents · 35 commands · 33 skills · 22 safety hooks</b> — in one install. No signup, no card.</p>
       <div class="chips">
         <span class="chip gold">60-second setup</span>
         <span class="chip">13 languages</span>

--- a/web/index.html
+++ b/web/index.html
@@ -15,7 +15,7 @@
 <meta property="og:image" content="https://sangrokjung.github.io/claude-forge/img/og.jpg">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
-<meta property="og:image:alt" content="Claude Forge — 16 agents, 35 commands, 33 skills, 21 safety hooks in one install">
+<meta property="og:image:alt" content="Claude Forge — 16 agents, 35 commands, 33 skills, 22 safety hooks in one install">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:image" content="https://sangrokjung.github.io/claude-forge/img/og.jpg">
 
@@ -270,7 +270,7 @@ details.help p{font-size:15.5px;color:var(--muted);padding-bottom:13px;line-heig
     <div class="stat"><b>16</b><span data-i18n="s2_lbl_agents"></span></div>
     <div class="stat"><b>35</b><span data-i18n="s2_lbl_commands"></span></div>
     <div class="stat"><b>32</b><span data-i18n="s2_lbl_skills"></span></div>
-    <div class="stat"><b>21</b><span data-i18n="s2_lbl_hooks"></span></div>
+    <div class="stat"><b>22</b><span data-i18n="s2_lbl_hooks"></span></div>
     <div class="stat"><b>14</b><span data-i18n="s2_lbl_rules"></span></div>
     <div class="stat"><b>4</b><span data-i18n="s2_lbl_mcp"></span></div>
   </div>


### PR DESCRIPTION
## What

Adds `hooks/session-time-report.sh`, the 22nd hook. It measures a session as it closes and hands you the summary at your next session start:

```
[Claude Forge] Previous session ended 21:34 KST
2h 17m elapsed · 18 prompts · 143 tool calls · 9 files changed
Log: ~/.claude/work-log/session-time-<session_id>.json
```

Transcript-only. No network call, no dependency beyond `python3`.

## Why it is wired to two events

`SessionEnd` is where the numbers are, but it cannot talk to you. `executeSessionEndHooks` forwards a hook's output **only when that hook failed**:

```js
for (let j of H)
  if (!j.succeeded && j.output)
    process.stderr.write(`SessionEnd hook [${j.command}] failed: ${j.output}\n`)
```

A successful report is discarded. Verified in the shipped CLI at both 2.0.76 and 2.1.170, so this is not version-specific. `SessionStart` is a surface that does reach the user (`forge-update-check.sh` already relies on it). Hence: record on the way out, report on the way in, exactly once.

## Why elapsed time is not last-minus-first

A transcript reopened with `--continue` spans hundreds of hours of wall clock. Measured on real transcripts in this repo's own project directory:

| transcript | whole span | latest stretch (60 min gap) |
|---|---|---|
| A | 21m | 21m |
| B | **416h 23m** | 1h 5m |
| C | **231h 10m** | 5m |
| D | 3h 11m | 3h 11m |

Reporting the whole span would be a false number on any resumed session. The timeline is split wherever an idle gap exceeds `FORGE_SESSION_GAP_MIN` (default 60), and the headline always describes the latest stretch. `(resumed 3x, 9h 40m total)` is appended only when the totals are trustworthy.

## Two catalog defects found while counting

Both predate this change and are corrected here, because the counts I am bumping depend on them:

1. `hooks/README.md` named `work-tracker-stop.sh` as the `SessionEnd` example, but `settings.json` wires it to `Stop`. Corrected, and it now has its own `Stop` row.
2. The README hook catalog held 20 rows for 21 shipped files: `forge-update-check.sh` had no entry anywhere. Adding a row for the new hook alone would have left 21 rows under a "22 Hooks" header.

## Counts

Hook count 21 → 22 in manifests, both installers, all three READMEs, `docs/MARKETPLACE-SUBMISSION.md` and the landing page. **Event coverage stays 21** on purpose: `SessionEnd` was already in the 27-event catalog, so no newly-covered event. Every remaining literal `21` was checked and left alone where it is either the event count or v4.0 history.

Version bumped to 4.2.0 across `plugin.json`, `marketplace.json`, both README file trees and the marketplace submission row, per the drift guard.

## Wiring note

The `SessionStart` entry uses the inline env form:

```json
"command": "FORGE_SESSION_MODE=report ~/.claude/hooks/session-time-report.sh"
```

not a trailing `--last`. The "Wired hooks are executable" gate resolves a hook command straight to a repo path, so `hooks/session-time-report.sh --last` would be looked up as a filename and fail the build. The script accepts `--last` too, for manual runs and tests.

## Verification

Local reproduction of every CI gate, all green:

- 6 JSON files parse; `settings.json` keeps its `hooks` object and v3 fields
- version drift guard: `plugin.json` == `marketplace.json` == `plugins[0]` == `4.2.0`
- **wired-hook exec check: 21 checked, 0 errors** (`git ls-files -s` shows `100755` for the new hook)
- no `hooks/hooks.json`; single `for dir in` loop; single `$directories` assignment
- `bash -n` over `install.sh` and all 22 hooks
- secret scan clean; doc-version-sync clean on both READMEs and the submission doc
- Korean em-dash gate: `python3 scripts/emdash_slop_check.py ... README.ko.md` → rc 0
- `shellcheck --severity=warning` clean on the new hook and its suite

Regression suites: `test_hook_guard` 8, `test_auto_resume_classify` 23, `test_s5_hooks` 15, `test_precommit_guard` 18, `test_emdash_check` 6, and the new `test_session_time_report` **31** — all pass.

The new suite is wired into the CI regression loop and covers: the resume invariant (a 5 h gap fixture must report 30m, never 6h 10m), per-stretch counts with meta and sidechain turns excluded, changed-file dedup, both output modes, drain-once, log mode `600`, `session_id` path-traversal sanitizing, the settings.json wiring resolving to a tracked file, and six silent-failure paths that must never disturb teardown.

Measured cost: the largest transcript on this machine (183 MB, 19,595 lines) parses in 0.35 s. `timeout: 10` is declared so the SessionEnd budget is raised off its 1.5 s default.

## Knobs

| Variable | Default | Effect |
|---|---|---|
| `FORGE_SESSION_TIME_REPORT` | `1` | `0` turns the hook off |
| `FORGE_SESSION_GAP_MIN` | `60` | idle minutes that start a new stretch |
| `FORGE_SESSION_MAX_MB` | `128` | transcript scan budget; larger files read from the tail |
| `FORGE_SESSION_REPORT_LANG` | auto | `en` / `ko`, auto-detected from `LANG` / `LC_ALL` |

## Out of scope (pre-existing drift, deliberately untouched)

`docs/PLUGIN-VS-INSTALL-SH.md`, `docs/STRUCTURE-VALIDATION.md` and `INSTALL.md` still say 15 hooks; `assets/readme/whats-inside*.html/.png` say 15; `docs/features-grid.jpg` says 14; `install.ps1` still claims 32 skills where `install.sh` says 33. `web/img/og.jpg` is a manual screenshot of `web/_og.html` and still shows 21 until it is re-shot. None of these were introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)