### PR TITLE
docs: make CONTRIBUTING match what CI actually accepts

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,7 +65,7 @@ You are a [role description]...
 - Follow the `<Agent_Prompt>` structure with `<Role>`, `<Constraints>`, `<Investigation_Protocol>`, `<Output_Format>` sections
 - Specify `model`. The kit's default is `sonnet` (10 of 16 agents); use `opus` only where the agent reasons over a whole codebase or arbitrates between other agents, and `haiku` for quick mechanical tasks.
 - Keep agent descriptions focused and specific. Copy the shape of [`agents/code-reviewer.md`](agents/code-reviewer.md).
-- Before opening the PR, run the same check CI runs:
+- Before opening the PR, run the same check CI runs (needs `pip install pyyaml jsonschema` once):
   `python3 -c "import json,re,sys,yaml;from jsonschema import validate;p=sys.argv[1];t=open(p).read();m=re.match(r'^---\n(.*?)\n---\n',t,re.S) or sys.exit('missing YAML frontmatter');validate(yaml.safe_load(m.group(1)),json.load(open('reference/agent-schema.json')));print('ok')" agents/my-agent.md`
 
 ### Commands (`commands/`)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,12 +23,17 @@ Thank you for your interest in contributing to Claude Forge!
 **File structure:**
 
 ```markdown
-# Part of Claude Forge — github.com/sangrokjung/claude-forge
 ---
 name: my-agent
-description: One-line description of the agent's purpose
+description: |
+  One line on what it does, then when to reach for it and which sibling
+  agent to use instead. Example: "Use proactively when ... For SQL use
+  database-reviewer."
 tools: ["Read", "Grep", "Glob"]
-model: opus
+model: sonnet
+memory: project
+maxTurns: 15
+color: blue
 ---
 
 <Agent_Prompt>
@@ -54,10 +59,14 @@ You are a [role description]...
 
 **Guidelines:**
 - One `.md` file per agent
+- **The file must start with `---` on line 1.** CI parses frontmatter with `^---\n(.*?)\n---\n`, so any line before the opening fence, including a comment, fails the build with `missing YAML frontmatter`. Do not add an attribution header; the Contributors section of the README carries credit.
+- Frontmatter is validated against [`reference/agent-schema.json`](reference/agent-schema.json) with `additionalProperties: false`. Only these keys are accepted: `name`, `description`, `tools`, `model`, `memory`, `maxTurns`, `color`, `skills`, `isolation`, `background`, `permissionMode`, `mcpServers`, `effort`, `hooks`, `disallowedTools`. Anything else (for example `author` or `allowedTools`) fails CI.
+- `tools` lists Claude Code tools (`Read`, `Grep`, `Bash`, `mcp__*`), not libraries the agent might talk about.
 - Follow the `<Agent_Prompt>` structure with `<Role>`, `<Constraints>`, `<Investigation_Protocol>`, `<Output_Format>` sections
-- Specify `model` (opus for deep analysis, sonnet for fast execution, haiku for quick tasks)
-- Include the Claude Forge attribution header at the top
-- Keep agent descriptions focused and specific
+- Specify `model`. The kit's default is `sonnet` (10 of 16 agents); use `opus` only where the agent reasons over a whole codebase or arbitrates between other agents, and `haiku` for quick mechanical tasks.
+- Keep agent descriptions focused and specific. Copy the shape of [`agents/code-reviewer.md`](agents/code-reviewer.md).
+- Before opening the PR, run the same check CI runs:
+  `python3 -c "import json,re,sys,yaml;from jsonschema import validate;p=sys.argv[1];t=open(p).read();m=re.match(r'^---\n(.*?)\n---\n',t,re.S) or sys.exit('missing YAML frontmatter');validate(yaml.safe_load(m.group(1)),json.load(open('reference/agent-schema.json')));print('ok')" agents/my-agent.md`
 
 ### Commands (`commands/`)
 
@@ -132,7 +141,7 @@ Types: `feat`, `fix`, `refactor`, `docs`, `test`, `chore`, `perf`, `ci`
 ## Contributor Benefits
 
 - **README recognition**: All contributors are permanently featured in the Contributors section via [contrib.rocks](https://contrib.rocks)
-- **Agent author credit**: When you create a new agent, your GitHub username is credited in the agent file's frontmatter (`author` field)
+- **Agent author credit**: your GitHub username is credited in the pull request and the README Contributors section. Agent files themselves carry no author field; the schema rejects it.
 - **Good First Issues**: Look for issues labeled `good first issue` for a great starting point
 
 ## Publishing to the Plugin Directory

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -37,6 +37,6 @@ Identical to Method A but lets you inspect/modify the source before installing.
 
 **Verification:** After install, run `claude --version` (≥ 2.1.110 required) and check `ls ~/.claude/agents/ | wc -l` — should print at least 11.
 
-**Uninstall:** there is no `--uninstall` flag yet. Method A/C install symlinks into `~/.claude/` (`agents`, `rules`, `commands`, `scripts`, `skills`, `hooks`, `libs`, `reference`, `cc-chips`, `cc-chips-custom`, plus `settings.json`); remove those links by hand and restore your own `settings.json` from the backup `install.sh` wrote. A proper uninstall script is tracked in [PR #30](https://github.com/sangrokjung/claude-forge/pull/30).
+**Uninstall:** there is no `--uninstall` flag yet. Method A/C install symlinks into `~/.claude/` (`agents`, `rules`, `commands`, `scripts`, `skills`, `hooks`, `libs`, `reference`, `cc-chips`, `cc-chips-custom`, plus `settings.json`); remove those links by hand. `install.sh` backs up a pre-existing `~/.claude/` to `~/.claude.backup.<timestamp>/` on a fresh interactive install, but not on `--upgrade` and not when it runs non-interactively (`curl | bash`), so check for that directory before assuming there is a `settings.json` to restore. A proper uninstall script is tracked in [PR #30](https://github.com/sangrokjung/claude-forge/pull/30).
 
 **Troubleshooting:** [`docs/STRUCTURE-VALIDATION.md`](docs/STRUCTURE-VALIDATION.md) explains the directory layout if `~/.claude` is in an unusual state.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -37,6 +37,6 @@ Identical to Method A but lets you inspect/modify the source before installing.
 
 **Verification:** After install, run `claude --version` (≥ 2.1.110 required) and check `ls ~/.claude/agents/ | wc -l` — should print at least 11.
 
-**Uninstall:** `./install.sh --uninstall` removes the symlinks created by Method A/C without touching your `~/.claude/settings.json` user content.
+**Uninstall:** there is no `--uninstall` flag yet. Method A/C install symlinks into `~/.claude/` (`agents`, `rules`, `commands`, `scripts`, `skills`, `hooks`, `libs`, `reference`, `cc-chips`, `cc-chips-custom`, plus `settings.json`); remove those links by hand and restore your own `settings.json` from the backup `install.sh` wrote. A proper uninstall script is tracked in [PR #30](https://github.com/sangrokjung/claude-forge/pull/30).
 
 **Troubleshooting:** [`docs/STRUCTURE-VALIDATION.md`](docs/STRUCTURE-VALIDATION.md) explains the directory layout if `~/.claude` is in an unusual state.

--- a/docs/STRUCTURE-VALIDATION.md
+++ b/docs/STRUCTURE-VALIDATION.md
@@ -149,10 +149,10 @@ agents/
 | Check | Status | Details |
 |-------|--------|---------|
 | Files present | PASS | 11 agent `.md` files |
-| Frontmatter format | PASS (with note) | All agents use a custom format: line 1 is a comment (`# Part of Claude Forge`), then `---` YAML frontmatter with `name`, `description`, `tools` |
+| Frontmatter format | PASS | All agents start with `---` on line 1 (YAML frontmatter with `name`, `description`, `tools`, `model`, `memory`, `maxTurns`, `color`). No comment line precedes the fence; CI rejects one. |
 | Required fields | PASS | All have `name`, `description`, `tools` |
 
-**Format Note**: Official plugins don't specify an agents format in the example-plugin. Claude Forge agents use `---` YAML frontmatter which is the standard Claude Code agent format. The `# Part of Claude Forge` comment on line 1 before `---` is non-standard but Claude Code parser typically skips to the first `---`.
+**Format Note**: Official plugins don't specify an agents format in the example-plugin. Claude Forge agents use `---` YAML frontmatter, which is the standard Claude Code agent format, and the file starts with that fence. An earlier revision put a `# Part of Claude Forge` comment on line 1; it was removed because the CI frontmatter check requires the fence on line 1, and the contributing guide now says so.
 
 ---
 
@@ -277,4 +277,4 @@ These are not auto-loaded by Claude Code's plugin system but are used by the ins
 1. **HIGH**: Create `.mcp.json` at plugin root with flat format (from `mcp-servers.json`)
 2. **MEDIUM**: Add frontmatter to `build-fix.md`, `refactor-clean.md`, `eval.md` commands
 3. **LOW**: Remove extra fields from `plugin.json` for strict compatibility (optional, not breaking)
-4. **LOW**: Remove `# Part of Claude Forge` comment line before `---` in agent files (optional)
+4. ~~**LOW**: Remove `# Part of Claude Forge` comment line before `---` in agent files~~ Done; the guide and CI now agree.


### PR DESCRIPTION
## What

Three external agent PRs (#7, #8, #25 — five agents between them) fail the same CI job for the same reason, and the reason is this repository's own contributing guide, not the contributors.

| Guide said | CI / schema actually require |
|---|---|
| Put `# Part of Claude Forge` on line 1, before `---` | File must start with `---` (`^---\n(.*?)\n---\n`), else `missing YAML frontmatter` |
| Your name goes in an `author` frontmatter field | `reference/agent-schema.json` is `additionalProperties: false` and has no `author` |
| Example pins `model: opus` | 10 of 16 shipped agents use `sonnet` |

All 16 agents on `main` start with `---` and carry no header, so the guide was describing a format the kit itself does not use.

## Changes

- **CONTRIBUTING.md**: template now mirrors `agents/code-reviewer.md`; lists the schema's accepted keys verbatim; explains `tools` means Claude Code tools, not libraries (the confusion behind #7's "pandas, numpy" tools list); ends with the exact one-liner CI runs so a contributor can check locally first. The `author`-field promise is replaced with README Contributors credit, which is what actually happens.
- **docs/STRUCTURE-VALIDATION.md**: described the comment-before-fence layout as the kit's format; corrected.
- **INSTALL.md**: advertised `./install.sh --uninstall`, which does not exist (`grep -c uninstall install.sh` → 0). Now says so and points at #30, where a real uninstall script is proposed.

## Verification

The one-liner added to the guide, run against `main`: 16/16 agents pass. Run against PR #8's `agents/python-reviewer.md`: `missing YAML frontmatter`, identical to CI. Korean em-dash gate unaffected (no Korean files touched).

## Follow-up

Once this lands I will point #7, #8 and #25 at the corrected guide; each needs only the fence moved to line 1 and a `model` choice to pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)